### PR TITLE
fix: update the pension controller to include trust factor in the pay…

### DIFF
--- a/app/models/controllers/pension.py
+++ b/app/models/controllers/pension.py
@@ -176,12 +176,6 @@ class Controller:
             if not income_profiles
             else income_profiles[-1].starting_income
         )
-
-        # This base should technically be the present value of income level
-        # at the last year of work, but seeing as I don't have access to inflation
-        # when this is initialized and we're not too far from retirement
-        # anyway, I'll just say that the present value of the future income
-        # is roughly equal to the current income
         return final_compensation * years_worked / INTERVALS_PER_YEAR
 
     @staticmethod
@@ -229,4 +223,9 @@ class Controller:
         """
         if not self._strategy:
             return 0
-        return self._strategy.calc_payment(state)
+        payment = self._strategy.calc_payment(state)
+        return (
+            payment * state.user.admin.pension.trust_factor
+            if state.user.admin
+            else payment
+        )

--- a/app/models/controllers/social_security.py
+++ b/app/models/controllers/social_security.py
@@ -3,6 +3,7 @@
 Classes:
     Controller: Generate and provide social security payments
 """
+
 import math
 from abc import ABC, abstractmethod
 from app.util import index_extrapolator, max_earnings_extrapolator
@@ -471,4 +472,6 @@ class Controller:
             )
             if partners_spousal_benefit > partner_payment:
                 partner_payment = partners_spousal_benefit
+        user_payment *= state.user.social_security_pension.trust_factor
+        partner_payment *= state.user.partner.social_security_pension.trust_factor
         return user_payment, partner_payment


### PR DESCRIPTION
…ment calculation, ensuring that the final payment reflects the user's administrative settings. Additionally, modified the social security controller to apply trust factors for both user and partner payments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Apply trust factors to pension payments and to both user and partner Social Security payments.
> 
> - **Controllers**:
>   - **Pension (`app/models/controllers/pension.py`)**: Multiply strategy payment by `state.user.admin.pension.trust_factor` in `calc_payment`.
>   - **Social Security (`app/models/controllers/social_security.py`)**: After spousal comparisons, scale `user_payment` and `partner_payment` by their respective `social_security_pension.trust_factor`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ab00e55fedd973347121d05418f1e41542ba165. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->