### PR TITLE
feat(domain): Phase 2b job income

### DIFF
--- a/docs/superpowers/plans/2026-06-12-phase-2b-domain-job-income.md
+++ b/docs/superpowers/plans/2026-06-12-phase-2b-domain-job-income.md
@@ -9,6 +9,7 @@
 **Tech Stack:** Python 3.14, Pydantic v2, `Decimal` money math, pytest, uv workspace. Spec: `docs/superpowers/specs/2026-06-12-phase-2b-domain-job-income-design.md`.
 
 **Conventions for every task:**
+
 - Follow TDD: write the behavior test, scaffold to a *logical* red (`NotImplementedError`/stub), confirm the failure is logical (not `ImportError`/`AttributeError`), implement, confirm green.
 - Inject `today: date`; never read wall-clock time in logic or assertions.
 - Bind shared values to a variable referenced in both arrange and assert; import constants/defaults from source instead of copying literals.
@@ -19,26 +20,29 @@
 
 ## File Structure
 
-**`packages/core/`**
+`**packages/core/`**
+
 - `core/job.py` *(new)* — `Job`, `SabbaticalWindow` models + `Job` model-level validator (`annual_tax_deferred <= annual_income`).
 - `core/models.py` *(modify)* — add `PersonHousehold.jobs`; add `Household` sabbatical-window validator.
 - `core/timeline.py` *(modify)* — add `boundary_to_year_month()`; refactor `Timeline.index_of` to reuse it; add `Timeline.month_boundary()`; move the `core.models` import under `TYPE_CHECKING` to break the new `models → timeline` cycle.
 - `tests/test_job.py` *(new)* — `Job` validation, `Household` window validation, repository round-trip.
 - `tests/test_timeline.py` *(modify)* — `boundary_to_year_month` + `month_boundary` behavior.
 
-**`packages/domain/`**
+`**packages/domain/*`*
+
 - `domain/job_income/__init__.py` *(new)* — `PersonJobIncome`, `JobIncomeProjection`, `project_job_income()`.
 - `domain/job_income/compile.py` *(new)* — `project_job_gross()` (segment split + re-anchoring + projection).
 - `tests/test_job_income.py` *(new)* — compilation and projection behaviors.
 - `OVERVIEW.md` *(modify)* — job-income port status.
 
-**`docs/superpowers/plans/2026-06-12-rebuild-index.md`** *(modify)* — active-phase pointer at the end.
+`**docs/superpowers/plans/2026-06-12-rebuild-index.md*`* *(modify)* — active-phase pointer at the end.
 
 ---
 
 ## Task 1: `Job` and `SabbaticalWindow` config models
 
 **Files:**
+
 - Create: `packages/core/core/job.py`
 - Test: `packages/core/tests/test_job.py`
 
@@ -155,6 +159,7 @@ git commit -m "feat(core): add Job and SabbaticalWindow config models"
 ## Task 2: Persist `jobs` on `PersonHousehold`
 
 **Files:**
+
 - Modify: `packages/core/core/models.py`
 - Test: `packages/core/tests/test_job.py`
 
@@ -243,6 +248,7 @@ git commit -m "feat(core): persist jobs on PersonHousehold"
 ## Task 3: `boundary_to_year_month` resolver + break the import cycle
 
 **Files:**
+
 - Modify: `packages/core/core/timeline.py`
 - Test: `packages/core/tests/test_timeline.py`
 
@@ -318,7 +324,7 @@ if TYPE_CHECKING:
     from core.models import Household, PersonHousehold, Plan
 ```
 
-2. Implement the resolver:
+1. Implement the resolver:
 
 ```python
 def boundary_to_year_month(boundary: Boundary, household: Household) -> tuple[int, int]:
@@ -331,7 +337,7 @@ def boundary_to_year_month(boundary: Boundary, household: Household) -> tuple[in
     raise TypeError(f"Unknown boundary: {boundary!r}")
 ```
 
-3. Refactor `Timeline.index_of` to delegate:
+1. Refactor `Timeline.index_of` to delegate:
 
 ```python
     def index_of(self, boundary: Boundary) -> int:
@@ -357,6 +363,7 @@ git commit -m "feat(core): add boundary_to_year_month resolver and reuse in inde
 ## Task 4: `Timeline.month_boundary` (inverse of the offset)
 
 **Files:**
+
 - Modify: `packages/core/core/timeline.py`
 - Test: `packages/core/tests/test_timeline.py`
 
@@ -415,6 +422,7 @@ git commit -m "feat(core): add Timeline.month_boundary"
 ## Task 5: `Household` sabbatical-window validator
 
 **Files:**
+
 - Modify: `packages/core/core/models.py`
 - Test: `packages/core/tests/test_job.py`
 
@@ -436,7 +444,7 @@ def _household_with_person1_jobs(jobs: list[Job]) -> Household:
     )
 
 
-def test_overlapping_windows_rejected() -> None:
+def test_overlapping_sabbatical_windows_rejected() -> None:
     job = Job(
         annual_income=Decimal("100000"),
         sabbaticals=[
@@ -458,14 +466,15 @@ def test_overlapping_windows_rejected() -> None:
 
 
 def test_window_outside_explicit_job_bounds_rejected() -> None:
+    job_start_year = 2030
     job = Job(
         annual_income=Decimal("100000"),
-        start=CalendarMonthBoundary(year=2030, month=1),
-        end=CalendarMonthBoundary(year=2035, month=12),
+        start=CalendarMonthBoundary(year=job_start_year, month=1),
+        end=CalendarMonthBoundary(year=job_start_year + 5, month=12),
         sabbaticals=[
             SabbaticalWindow(
-                start=CalendarMonthBoundary(year=2029, month=1),
-                end=CalendarMonthBoundary(year=2029, month=6),
+                start=CalendarMonthBoundary(year=job_start_year - 1, month=1),
+                end=CalendarMonthBoundary(year=job_start_year - 1, month=6),
                 remaining_fraction=Decimal("0"),
             )
         ],
@@ -588,6 +597,7 @@ git commit -m "feat(core): validate sabbatical windows on Household"
 ## Task 6: Compile a job into a projected gross series
 
 **Files:**
+
 - Create: `packages/domain/domain/job_income/__init__.py` (empty package marker for now — a docstring only)
 - Create: `packages/domain/domain/job_income/compile.py`
 - Test: `packages/domain/tests/test_job_income.py`
@@ -798,6 +808,7 @@ git commit -m "feat(domain): compile jobs into projected gross series with sabba
 ## Task 7: `project_job_income` aggregator + result types
 
 **Files:**
+
 - Modify: `packages/domain/domain/job_income/__init__.py`
 - Test: `packages/domain/tests/test_job_income.py`
 
@@ -958,10 +969,6 @@ Expected: FAIL with `NotImplementedError`.
 Replace the stub bodies in `__init__.py`:
 
 ```python
-def _zeros(length: int) -> list[Decimal]:
-    return [Decimal("0.00")] * length
-
-
 def _add(left: list[Decimal], right: list[Decimal]) -> list[Decimal]:
     return [a + b for a, b in zip(left, right, strict=True)]
 
@@ -975,25 +982,16 @@ class PersonJobIncome(BaseModel):
 class JobIncomeProjection(BaseModel):
     person1: PersonJobIncome
     person2: PersonJobIncome
-
-    @property
-    def total_gross(self) -> list[Decimal]:
-        return _add(self.person1.gross, self.person2.gross)
-
-    @property
-    def total_ss_covered_gross(self) -> list[Decimal]:
-        return _add(self.person1.ss_covered_gross, self.person2.ss_covered_gross)
-
-    @property
-    def total_tax_deferred(self) -> list[Decimal]:
-        return _add(self.person1.tax_deferred, self.person2.tax_deferred)
+    total_gross: list[Decimal]
+    total_ss_covered_gross: list[Decimal]
+    total_tax_deferred: list[Decimal]
 
 
 def _project_person(person: PersonHousehold, timeline: Timeline) -> PersonJobIncome:
     horizon = timeline.horizon_months
-    gross = _zeros(horizon)
-    ss_covered = _zeros(horizon)
-    tax_deferred = _zeros(horizon)
+    gross = [Decimal("0.00")] * horizon
+    ss_covered = [Decimal("0.00")] * horizon
+    tax_deferred = [Decimal("0.00")] * horizon
     for job in person.jobs:
         job_gross = project_job_gross(job, timeline)
         gross = _add(gross, job_gross)
@@ -1012,9 +1010,14 @@ def _project_person(person: PersonHousehold, timeline: Timeline) -> PersonJobInc
 
 
 def project_job_income(plan: Plan, timeline: Timeline) -> JobIncomeProjection:
+    person1 = _project_person(plan.household.person1, timeline)
+    person2 = _project_person(plan.household.person2, timeline)
     return JobIncomeProjection(
-        person1=_project_person(plan.household.person1, timeline),
-        person2=_project_person(plan.household.person2, timeline),
+        person1=person1,
+        person2=person2,
+        total_gross=_add(person1.gross, person2.gross),
+        total_ss_covered_gross=_add(person1.ss_covered_gross, person2.ss_covered_gross),
+        total_tax_deferred=_add(person1.tax_deferred, person2.tax_deferred),
     )
 ```
 
@@ -1036,6 +1039,7 @@ git commit -m "feat(domain): aggregate per-person and household job income proje
 ## Task 8: Documentation + active-phase pointer + full gate
 
 **Files:**
+
 - Modify: `packages/domain/OVERVIEW.md`
 - Modify: `docs/superpowers/plans/2026-06-12-rebuild-index.md`
 
@@ -1080,12 +1084,13 @@ git commit -m "docs: mark Phase 2b job income complete; point index at Phase 2c"
 ## Self-Review
 
 **Spec coverage (spec §-by-§):**
+
 - §3 models → Tasks 1, 2. §3 validation (field/Job/Household) → Tasks 1, 5. §3 `boundary_to_year_month` + `index_of` reuse → Task 3.
 - §4 segmented compilation + re-anchoring + `month_boundary` → Tasks 4, 6.
 - §5 `JobIncomeProjection` per-person + totals; uncapped `ss_covered_gross`; tax-deferred fraction (incl. `annual_income==0`) → Task 7.
 - §6 file layout → all tasks. §7 testing table → tests across Tasks 1–7. §8 error handling → Tasks 1, 5, 6. §9 exit criteria → Task 8 + suite. §10 deferred → not implemented (correct).
 
-**Type consistency:** `project_job_gross(job, timeline) -> list[Decimal]` (Task 6) is consumed unchanged in Task 7. `PersonJobIncome` fields `gross` / `ss_covered_gross` / `tax_deferred` and `JobIncomeProjection.person1/person2` + `total_*` properties are consistent between definition (Task 7) and tests. `boundary_to_year_month(boundary, household)` signature matches its caller in `index_of` (Task 3) and `_validate_job_windows` (Task 5). `Timeline.month_boundary(index)` matches usage in `_segment_stream` (Task 6).
+**Type consistency:** `project_job_gross(job, timeline) -> list[Decimal]` (Task 6) is consumed unchanged in Task 7. `PersonJobIncome` fields `gross` / `ss_covered_gross` / `tax_deferred` and `JobIncomeProjection.person1/person2` + `total_`* properties are consistent between definition (Task 7) and tests. `boundary_to_year_month(boundary, household)` signature matches its caller in `index_of` (Task 3) and `_validate_job_windows` (Task 5). `Timeline.month_boundary(index)` matches usage in `_segment_stream` (Task 6).
 
 **Placeholder scan:** no `TBD`/`TODO`/"handle edge cases"; every code step shows complete code; every test step shows the assertion.
 

--- a/docs/superpowers/plans/2026-06-12-phase-2b-domain-job-income.md
+++ b/docs/superpowers/plans/2026-06-12-phase-2b-domain-job-income.md
@@ -1,0 +1,852 @@
+# Phase 2b — Domain: Job Income Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port legacy job income onto the Phase 2a `TimedStream` foundation — multiple jobs per person, each with per-job sabbatical windows (full break or % reduction), projected into per-person month-indexed series for Phase 2c/2d.
+
+**Architecture:** Config models (`Job`, `SabbaticalWindow`) live in `core` and persist on `PersonHousehold.jobs`. A `Household` Pydantic validator enforces sabbatical-window structure using birth-date-only boundary resolution. The `domain.job_income` package compiles each job into re-anchored `TimedStream` segments (reusing `core.timeline.project_stream`) and aggregates them into a `JobIncomeProjection`.
+
+**Tech Stack:** Python 3.14, Pydantic v2, `Decimal`, pytest, uv workspace. Run all commands from the repo root `/Users/chris/Projects/life-finances-workspace/LifeFInances`.
+
+**Status:** in progress
+
+**Spec:** [`docs/superpowers/specs/2026-06-12-phase-2b-domain-job-income-design.md`](../specs/2026-06-12-phase-2b-domain-job-income-design.md)
+
+---
+
+## File structure
+
+| File | Responsibility |
+|------|----------------|
+| `packages/core/core/job.py` (new) | `Job`, `SabbaticalWindow` config models + `Job`-level validator |
+| `packages/core/core/models.py` (modify) | `PersonHousehold.jobs`; `Household` sabbatical-window validator |
+| `packages/core/core/timeline.py` (modify) | `boundary_to_year_month` resolver; `Timeline.month_boundary`; `index_of` reuses resolver |
+| `packages/domain/domain/job_income/__init__.py` (new) | `project_job_income`, `JobIncomeProjection`, `PersonJobIncome` |
+| `packages/domain/domain/job_income/compile.py` (new) | `compile_job_to_streams` (segment split + re-anchoring) |
+| `packages/core/tests/test_job.py` (new) | `Job` + `Household` validation, repository round-trip |
+| `packages/core/tests/test_timeline.py` (modify) | `boundary_to_year_month`, `month_boundary` |
+| `packages/domain/tests/test_job_income.py` (new) | compiler + projection behavior |
+| `packages/domain/OVERVIEW.md` (modify) | job-income port status |
+| `docs/superpowers/plans/2026-06-12-rebuild-index.md` (modify) | mark Phase 2b complete |
+
+**Build order:** Task 1 (models) → Task 2 (wire + persist) → Task 3 (resolver/helpers) → Task 4 (Household validator) → Task 5 (compiler) → Task 6 (projection) → Task 7 (docs + green).
+
+---
+
+## Task 1: `Job` and `SabbaticalWindow` config models
+
+**Files:**
+- Create: `packages/core/core/job.py`
+- Test: `packages/core/tests/test_job.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/tests/test_job.py`:
+
+```python
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from core.job import Job, SabbaticalWindow
+from core.streams import CalendarMonthBoundary
+from pydantic import ValidationError
+
+
+def test_job_rejects_tax_deferred_above_income() -> None:
+    income = Decimal("100000")
+    too_much = income + Decimal("1")
+
+    with pytest.raises(ValidationError):
+        Job(annual_income=income, annual_tax_deferred=too_much)
+
+
+def test_job_allows_tax_deferred_equal_to_income() -> None:
+    income = Decimal("80000")
+
+    job = Job(annual_income=income, annual_tax_deferred=income)
+
+    assert job.annual_tax_deferred == income
+
+
+def test_sabbatical_window_rejects_remaining_fraction_above_one() -> None:
+    with pytest.raises(ValidationError):
+        SabbaticalWindow(
+            start=CalendarMonthBoundary(year=2030, month=1),
+            end=CalendarMonthBoundary(year=2030, month=6),
+            remaining_fraction=Decimal("1.5"),
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest packages/core/tests/test_job.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'core.job'`. If so, add the empty scaffold below and re-run; expected next failure is logical (`ValidationError` not raised). Confirm the failure is logical before implementing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `packages/core/core/job.py`:
+
+```python
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, Field, model_validator
+
+from core.streams import Boundary
+
+
+class SabbaticalWindow(BaseModel):
+    """A window over which a job's pay is reduced (or fully paused).
+
+    `remaining_fraction` is the share of pay still earned: 0 => full break,
+    0.5 => half pay, 1 => no reduction. The job's underlying raise clock keeps
+    running across the window, so the person returns at the grown salary.
+    Window ordering / overlap / containment is validated on `Household`.
+    """
+
+    start: Boundary
+    end: Boundary
+    remaining_fraction: Decimal = Field(ge=0, le=1)
+
+
+class Job(BaseModel):
+    """One job held by a person, modeled as a real (today's-dollar) income source.
+
+    Amounts are annual; the domain compiles them to a monthly stream.
+    `annual_raise` is a REAL raise (growth above inflation). Inflation is never
+    applied here.
+    """
+
+    label: str | None = None
+    annual_income: Decimal = Field(ge=0)
+    annual_tax_deferred: Decimal = Field(default=Decimal(0), ge=0)
+    annual_raise: Decimal = Decimal(0)
+    start: Boundary | None = None
+    end: Boundary | None = None
+    social_security_eligible: bool = True
+    sabbaticals: list[SabbaticalWindow] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _tax_deferred_within_income(self) -> Job:
+        if self.annual_tax_deferred > self.annual_income:
+            raise ValueError("annual_tax_deferred must not exceed annual_income")
+        return self
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest packages/core/tests/test_job.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/core/job.py packages/core/tests/test_job.py
+git commit -m "feat(core): add Job and SabbaticalWindow config models"
+```
+
+---
+
+## Task 2: Wire `PersonHousehold.jobs` and prove SQLite round-trip
+
+**Files:**
+- Modify: `packages/core/core/models.py`
+- Test: `packages/core/tests/test_repository.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/core/tests/test_repository.py`:
+
+```python
+def test_round_trip_preserves_person_jobs(repo: PlanRepository) -> None:
+    from decimal import Decimal
+
+    from core.job import Job, SabbaticalWindow
+    from core.streams import CalendarMonthBoundary
+
+    plan_id, plan = repo.get_or_create_default()
+    expected_income = Decimal("123456.78")
+    job = Job(
+        label="Engineer",
+        annual_income=expected_income,
+        annual_tax_deferred=Decimal("23000"),
+        annual_raise=Decimal("0.03"),
+        sabbaticals=[
+            SabbaticalWindow(
+                start=CalendarMonthBoundary(year=2032, month=1),
+                end=CalendarMonthBoundary(year=2032, month=12),
+                remaining_fraction=Decimal("0.5"),
+            )
+        ],
+    )
+    plan.household.person1.jobs = [job]
+
+    repo.save(plan_id, plan)
+    loaded = repo.get_by_id(plan_id)
+
+    assert loaded is not None
+    loaded_job = loaded.household.person1.jobs[0]
+    assert loaded_job.annual_income == expected_income
+    assert loaded_job.sabbaticals[0].remaining_fraction == Decimal("0.5")
+    assert isinstance(loaded_job.sabbaticals[0].start, CalendarMonthBoundary)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest packages/core/tests/test_repository.py::test_round_trip_preserves_person_jobs -v`
+Expected: FAIL — logical failure setting `.jobs` (Pydantic `ValueError` "object has no field 'jobs'") because `PersonHousehold` has no `jobs` field yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `packages/core/core/models.py`. Add the import and the field:
+
+```python
+from core.job import Job
+from core.streams import TimedStream
+
+
+class PersonHousehold(BaseModel):
+    birth_month: int = Field(ge=1, le=12)
+    birth_year: int
+    max_age_years: int = Field(default=100, ge=1)
+    jobs: list[Job] = Field(default_factory=list)
+```
+
+(Keep the existing `Household`, `Portfolio`, `Plan` classes unchanged in this task.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest packages/core/tests/test_repository.py -v`
+Expected: PASS (all repository tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/core/models.py packages/core/tests/test_repository.py
+git commit -m "feat(core): persist per-person jobs on PersonHousehold"
+```
+
+---
+
+## Task 3: `boundary_to_year_month` resolver + `Timeline.month_boundary`
+
+**Files:**
+- Modify: `packages/core/core/timeline.py`
+- Test: `packages/core/tests/test_timeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/core/tests/test_timeline.py`:
+
+```python
+from core.timeline import boundary_to_year_month
+
+
+def test_boundary_to_year_month_resolves_person_age_without_today() -> None:
+    plan = default_plan()
+    person = plan.household.person1
+    age_months = 480  # 40 years
+
+    year, month = boundary_to_year_month(
+        PersonAgeBoundary(person="person1", age_months=age_months),
+        plan.household,
+    )
+
+    assert year == person.birth_year + age_months // 12
+    assert month == person.birth_month
+
+
+def test_month_boundary_is_inverse_of_index_of() -> None:
+    today = date(2026, 6, 1)
+    plan = default_plan()
+    timeline = Timeline(plan, today=today)
+    index = 27
+
+    boundary = timeline.month_boundary(index)
+
+    assert timeline.index_of(boundary) == index
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest packages/core/tests/test_timeline.py -k "boundary_to_year_month or month_boundary" -v`
+Expected: FAIL with `ImportError` for `boundary_to_year_month`. Add the scaffolds (a `boundary_to_year_month` that returns `(0, 0)` and a `month_boundary` returning `CalendarMonthBoundary(year=0, month=1)`), re-run, confirm the failure is now logical (`AssertionError`) before implementing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `packages/core/core/timeline.py`. Add the import of `Household` and the resolver, and refactor `index_of` to reuse it; add `month_boundary`:
+
+```python
+from core.models import Household, PersonHousehold, Plan
+
+
+def boundary_to_year_month(boundary: Boundary, household: Household) -> tuple[int, int]:
+    """Resolve a boundary to an absolute (year, month). Birth-date only; no `today`."""
+    if isinstance(boundary, CalendarMonthBoundary):
+        return boundary.year, boundary.month
+    if isinstance(boundary, PersonAgeBoundary):
+        person = getattr(household, boundary.person)
+        return add_months(person.birth_year, person.birth_month, boundary.age_months)
+    raise TypeError(f"Unknown boundary: {boundary!r}")
+```
+
+Replace the body of `Timeline.index_of` with:
+
+```python
+    def index_of(self, boundary: Boundary) -> int:
+        year, month = boundary_to_year_month(boundary, self.plan.household)
+        return self._offset(year, month)
+```
+
+Add to `Timeline`:
+
+```python
+    def month_boundary(self, index: int) -> CalendarMonthBoundary:
+        """The calendar month at `index` months from today (index 0 == this month)."""
+        year, month = add_months(self.today.year, self.today.month, index)
+        return CalendarMonthBoundary(year=year, month=month)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest packages/core/tests/test_timeline.py -v`
+Expected: PASS (existing + 2 new tests; `index_of` tests still green after refactor).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/core/timeline.py packages/core/tests/test_timeline.py
+git commit -m "feat(core): add boundary_to_year_month resolver and Timeline.month_boundary"
+```
+
+---
+
+## Task 4: `Household` sabbatical-window validator
+
+**Files:**
+- Modify: `packages/core/core/models.py`
+- Test: `packages/core/tests/test_job.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/core/tests/test_job.py`:
+
+```python
+from core.models import Household, PersonHousehold
+
+
+def _person(birth_year: int, jobs: list[Job]) -> PersonHousehold:
+    return PersonHousehold(birth_month=1, birth_year=birth_year, jobs=jobs)
+
+
+def _window(start_month: int, end_month: int, remaining: str = "0") -> SabbaticalWindow:
+    return SabbaticalWindow(
+        start=CalendarMonthBoundary(year=2030, month=start_month),
+        end=CalendarMonthBoundary(year=2030, month=end_month),
+        remaining_fraction=Decimal(remaining),
+    )
+
+
+def test_household_rejects_overlapping_sabbatical_windows() -> None:
+    job = Job(annual_income=Decimal("100000"), sabbaticals=[_window(1, 6), _window(5, 9)])
+
+    with pytest.raises(ValidationError):
+        Household(person1=_person(1980, [job]), person2=_person(1982, []))
+
+
+def test_household_rejects_window_outside_explicit_job_bounds() -> None:
+    job = Job(
+        annual_income=Decimal("100000"),
+        start=CalendarMonthBoundary(year=2030, month=3),
+        end=CalendarMonthBoundary(year=2030, month=8),
+        sabbaticals=[_window(1, 4)],  # starts before job start
+    )
+
+    with pytest.raises(ValidationError):
+        Household(person1=_person(1980, [job]), person2=_person(1982, []))
+
+
+def test_household_accepts_ordered_in_bounds_windows() -> None:
+    job = Job(annual_income=Decimal("100000"), sabbaticals=[_window(1, 3), _window(5, 7)])
+
+    household = Household(person1=_person(1980, [job]), person2=_person(1982, []))
+
+    assert household.person1.jobs[0].sabbaticals[1].start.month == 5
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest packages/core/tests/test_job.py -k household -v`
+Expected: FAIL — logical failure: the two "reject" tests do not raise `ValidationError` because no `Household` validator exists yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `packages/core/core/models.py`. Add a `model_validator(mode="after")` to `Household` (import `model_validator` from pydantic). The `boundary_to_year_month` import is local to avoid a circular import with `core.timeline`:
+
+```python
+from pydantic import BaseModel, Field, model_validator
+
+
+class Household(BaseModel):
+    person1: PersonHousehold
+    person2: PersonHousehold
+
+    @model_validator(mode="after")
+    def _validate_sabbatical_windows(self) -> "Household":
+        from core.timeline import boundary_to_year_month
+
+        def abs_month(boundary) -> int:
+            year, month = boundary_to_year_month(boundary, self)
+            return year * 12 + (month - 1)
+
+        for person in (self.person1, self.person2):
+            for job in person.jobs:
+                job_lo = abs_month(job.start) if job.start is not None else None
+                job_hi = abs_month(job.end) if job.end is not None else None
+                prev_end: int | None = None
+                for window in job.sabbaticals:
+                    start = abs_month(window.start)
+                    end = abs_month(window.end)
+                    if start > end:
+                        raise ValueError("sabbatical window start must not be after end")
+                    if job_lo is not None and start < job_lo:
+                        raise ValueError("sabbatical window starts before job start")
+                    if job_hi is not None and end > job_hi:
+                        raise ValueError("sabbatical window ends after job end")
+                    if prev_end is not None and start <= prev_end:
+                        raise ValueError("sabbatical windows must be ordered and non-overlapping")
+                    prev_end = end
+        return self
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest packages/core/tests/test_job.py -v`
+Expected: PASS (all `Job` + `Household` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/core/models.py packages/core/tests/test_job.py
+git commit -m "feat(core): validate sabbatical windows on Household"
+```
+
+---
+
+## Task 5: Compile a `Job` into re-anchored `TimedStream` segments
+
+**Files:**
+- Create: `packages/domain/domain/job_income/__init__.py`
+- Create: `packages/domain/domain/job_income/compile.py`
+- Test: `packages/domain/tests/test_job_income.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/domain/tests/test_job_income.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from core.defaults import default_plan
+from core.job import Job, SabbaticalWindow
+from core.streams import CalendarMonthBoundary
+from core.timeline import Timeline, project_stream
+from domain.job_income.compile import compile_job_to_streams
+
+
+def _timeline() -> Timeline:
+    return Timeline(default_plan(), today=date(2026, 1, 1))
+
+
+def _project(job: Job, timeline: Timeline) -> list[Decimal]:
+    horizon = timeline.horizon_months
+    totals = [Decimal("0.00")] * horizon
+    for stream in compile_job_to_streams(job, timeline):
+        for index, value in enumerate(project_stream(stream, timeline)):
+            totals[index] += value
+    return totals
+
+
+def test_single_job_converts_annual_to_monthly() -> None:
+    timeline = _timeline()
+    annual = Decimal("120000")
+    job = Job(annual_income=annual)
+
+    series = _project(job, timeline)
+
+    assert series[0] == (annual / 12).quantize(Decimal("0.01"))
+
+
+def test_full_break_resumes_on_the_no_break_growth_curve() -> None:
+    timeline = _timeline()
+    annual = Decimal("120000")
+    rate = Decimal("0.12")
+    break_start, break_end = 12, 23
+    resume_index = break_end + 1
+    windowed = Job(
+        annual_income=annual,
+        annual_raise=rate,
+        sabbaticals=[
+            SabbaticalWindow(
+                start=timeline.month_boundary(break_start),
+                end=timeline.month_boundary(break_end),
+                remaining_fraction=Decimal("0"),
+            )
+        ],
+    )
+    continuous = Job(annual_income=annual, annual_raise=rate)
+
+    windowed_series = _project(windowed, timeline)
+    continuous_series = _project(continuous, timeline)
+
+    assert windowed_series[break_start] == Decimal("0.00")
+    assert windowed_series[resume_index] == continuous_series[resume_index]
+
+
+def test_partial_reduction_scales_grown_amount() -> None:
+    timeline = _timeline()
+    annual = Decimal("120000")
+    rate = Decimal("0.12")
+    remaining = Decimal("0.5")
+    reduce_at = 12
+    reduced = Job(
+        annual_income=annual,
+        annual_raise=rate,
+        sabbaticals=[
+            SabbaticalWindow(
+                start=timeline.month_boundary(reduce_at),
+                end=timeline.month_boundary(reduce_at + 5),
+                remaining_fraction=remaining,
+            )
+        ],
+    )
+    full = Job(annual_income=annual, annual_raise=rate)
+
+    reduced_series = _project(reduced, timeline)
+    full_series = _project(full, timeline)
+
+    expected = (full_series[reduce_at] * remaining).quantize(Decimal("0.01"))
+    assert reduced_series[reduce_at] == expected
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest packages/domain/tests/test_job_income.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'domain.job_income'`. Add the package scaffold (empty `__init__.py` and a `compile_job_to_streams` returning `[]`), re-run, and confirm the failure is logical (`AssertionError` / `IndexError`) before implementing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `packages/domain/domain/job_income/__init__.py`:
+
+```python
+"""Job income: compile jobs into timed-stream segments and project them."""
+```
+
+Create `packages/domain/domain/job_income/compile.py`:
+
+```python
+from __future__ import annotations
+
+from decimal import Decimal
+
+from core.job import Job
+from core.streams import TimedStream
+from core.timeline import Timeline
+
+
+def compile_job_to_streams(job: Job, timeline: Timeline) -> list[TimedStream]:
+    """Split a job into full/reduced `TimedStream` segments.
+
+    Each segment's base is re-anchored to the job's start so the segments stitch
+    into one continuous `base * (1 + raise) ** ((t - job_start) / 12)` curve,
+    scaled by `remaining_fraction` inside sabbatical windows (Phase 2a §6.1).
+    """
+    base_monthly = job.annual_income / Decimal(12)
+    growth_base = Decimal(1) + job.annual_raise
+    job_start_index = 0 if job.start is None else timeline.index_of(job.start)
+    job_end_index = None if job.end is None else timeline.index_of(job.end)
+
+    windows = [
+        (
+            timeline.index_of(window.start),
+            timeline.index_of(window.end),
+            window.remaining_fraction,
+        )
+        for window in job.sabbaticals
+    ]
+
+    streams: list[TimedStream] = []
+
+    def make_segment(start_index: int, end_index: int | None, remaining: Decimal) -> None:
+        exponent = Decimal(start_index - job_start_index) / Decimal(12)
+        segment_base = base_monthly * remaining * (growth_base**exponent)
+        streams.append(
+            TimedStream(
+                monthly_amount=segment_base,
+                start=timeline.month_boundary(start_index),
+                end=None if end_index is None else timeline.month_boundary(end_index),
+                annual_growth_rate=job.annual_raise,
+                is_nominal=False,
+            )
+        )
+
+    cursor = job_start_index
+    for window_start, window_end, remaining in windows:
+        if cursor <= window_start - 1:
+            make_segment(cursor, window_start - 1, Decimal(1))
+        make_segment(window_start, window_end, remaining)
+        cursor = window_end + 1
+
+    if job_end_index is None:
+        make_segment(cursor, None, Decimal(1))
+    elif cursor <= job_end_index:
+        make_segment(cursor, job_end_index, Decimal(1))
+
+    return streams
+```
+
+> Note: `monthly_amount` must be `>= 0`; `remaining_fraction` is in `[0, 1]` and the growth factor is positive, so `segment_base >= 0` always holds.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest packages/domain/tests/test_job_income.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/domain/domain/job_income/__init__.py packages/domain/domain/job_income/compile.py packages/domain/tests/test_job_income.py
+git commit -m "feat(domain): compile jobs into re-anchored sabbatical-aware stream segments"
+```
+
+---
+
+## Task 6: `project_job_income` → `JobIncomeProjection`
+
+**Files:**
+- Modify: `packages/domain/domain/job_income/__init__.py`
+- Test: `packages/domain/tests/test_job_income.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/domain/tests/test_job_income.py`:
+
+```python
+from domain.job_income import JobIncomeProjection, project_job_income
+
+
+def _plan_with_jobs(person1_jobs, person2_jobs):
+    plan = default_plan()
+    plan.household.person1.jobs = person1_jobs
+    plan.household.person2.jobs = person2_jobs
+    return plan
+
+
+def test_concurrent_jobs_sum_per_person() -> None:
+    timeline = _timeline()
+    job_a = Job(annual_income=Decimal("60000"))
+    job_b = Job(annual_income=Decimal("36000"))
+    plan = _plan_with_jobs([job_a, job_b], [])
+
+    projection = project_job_income(plan, timeline)
+
+    expected = (Decimal("60000") / 12 + Decimal("36000") / 12).quantize(Decimal("0.01"))
+    assert projection.person1.gross[0] == expected
+
+
+def test_ss_covered_gross_excludes_non_covered_job_and_applies_no_cap() -> None:
+    timeline = _timeline()
+    covered = Job(annual_income=Decimal("90000"), social_security_eligible=True)
+    not_covered = Job(annual_income=Decimal("90000"), social_security_eligible=False)
+    plan = _plan_with_jobs([covered, not_covered], [])
+
+    projection = project_job_income(plan, timeline)
+
+    covered_monthly = (Decimal("90000") / 12).quantize(Decimal("0.01"))
+    assert projection.person1.gross[0] == covered_monthly * 2
+    assert projection.person1.ss_covered_gross[0] == covered_monthly
+
+
+def test_tax_deferred_is_fraction_of_gross() -> None:
+    timeline = _timeline()
+    annual_income = Decimal("100000")
+    annual_deferred = Decimal("20000")
+    job = Job(annual_income=annual_income, annual_tax_deferred=annual_deferred)
+    plan = _plan_with_jobs([job], [])
+
+    projection = project_job_income(plan, timeline)
+
+    fraction = annual_deferred / annual_income
+    expected = (projection.person1.gross[0] * fraction).quantize(Decimal("0.01"))
+    assert projection.person1.tax_deferred[0] == expected
+
+
+def test_household_total_gross_equals_per_person_sum() -> None:
+    timeline = _timeline()
+    plan = _plan_with_jobs(
+        [Job(annual_income=Decimal("60000"))],
+        [Job(annual_income=Decimal("48000"))],
+    )
+
+    projection = project_job_income(plan, timeline)
+
+    assert projection.total_gross[0] == (
+        projection.person1.gross[0] + projection.person2.gross[0]
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest packages/domain/tests/test_job_income.py -k "per_person or covered or tax_deferred or total" -v`
+Expected: FAIL with `ImportError` for `project_job_income` / `JobIncomeProjection`. Add the scaffolds (classes with the listed fields + a `project_job_income` returning a zero-filled projection), re-run, confirm logical failure (`AssertionError`) before implementing.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the contents of `packages/domain/domain/job_income/__init__.py`:
+
+```python
+"""Job income: compile jobs into timed-stream segments and project them."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from core.models import PersonHousehold, Plan
+from core.timeline import Timeline, project_stream
+from pydantic import BaseModel
+
+from domain.job_income.compile import compile_job_to_streams
+
+_CENTS = Decimal("0.01")
+
+
+class PersonJobIncome(BaseModel):
+    gross: list[Decimal]
+    ss_covered_gross: list[Decimal]
+    tax_deferred: list[Decimal]
+
+
+def _sum(left: list[Decimal], right: list[Decimal]) -> list[Decimal]:
+    return [a + b for a, b in zip(left, right, strict=True)]
+
+
+class JobIncomeProjection(BaseModel):
+    person1: PersonJobIncome
+    person2: PersonJobIncome
+
+    @property
+    def total_gross(self) -> list[Decimal]:
+        return _sum(self.person1.gross, self.person2.gross)
+
+    @property
+    def total_ss_covered_gross(self) -> list[Decimal]:
+        return _sum(self.person1.ss_covered_gross, self.person2.ss_covered_gross)
+
+    @property
+    def total_tax_deferred(self) -> list[Decimal]:
+        return _sum(self.person1.tax_deferred, self.person2.tax_deferred)
+
+
+def _project_person(person: PersonHousehold, timeline: Timeline) -> PersonJobIncome:
+    horizon = timeline.horizon_months
+    gross = [Decimal("0.00")] * horizon
+    ss_covered = [Decimal("0.00")] * horizon
+    tax_deferred = [Decimal("0.00")] * horizon
+
+    for job in person.jobs:
+        fraction = (
+            job.annual_tax_deferred / job.annual_income
+            if job.annual_income
+            else Decimal(0)
+        )
+        job_series = [Decimal("0.00")] * horizon
+        for stream in compile_job_to_streams(job, timeline):
+            for index, value in enumerate(project_stream(stream, timeline)):
+                job_series[index] += value
+        for index in range(horizon):
+            month_gross = job_series[index]
+            gross[index] += month_gross
+            if job.social_security_eligible:
+                ss_covered[index] += month_gross
+            tax_deferred[index] += (month_gross * fraction).quantize(_CENTS)
+
+    return PersonJobIncome(
+        gross=gross, ss_covered_gross=ss_covered, tax_deferred=tax_deferred
+    )
+
+
+def project_job_income(plan: Plan, timeline: Timeline) -> JobIncomeProjection:
+    return JobIncomeProjection(
+        person1=_project_person(plan.household.person1, timeline),
+        person2=_project_person(plan.household.person2, timeline),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest packages/domain/tests/test_job_income.py -v`
+Expected: PASS (all compiler + projection tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/domain/domain/job_income/__init__.py packages/domain/tests/test_job_income.py
+git commit -m "feat(domain): aggregate jobs into a per-person JobIncomeProjection"
+```
+
+---
+
+## Task 7: Update docs and confirm full green
+
+**Files:**
+- Modify: `packages/domain/OVERVIEW.md`
+- Modify: `docs/superpowers/plans/2026-06-12-rebuild-index.md`
+
+- [ ] **Step 1: Mark the job-income port done in `packages/domain/OVERVIEW.md`**
+
+Change the port-map row:
+
+```markdown
+| `job_income.py` (incl. planned sabbaticals) | `domain/job_income/` | 2b | done |
+```
+
+- [ ] **Step 2: Update the rebuild index**
+
+In `docs/superpowers/plans/2026-06-12-rebuild-index.md`:
+- Check the four Phase 2b exit-criteria boxes (`- [x]`).
+- In the **Active phase** table set current phase to `Phase 2c — plan`, active plan to `2026-06-12-phase-2c-domain-social-security.md`, next action to "Write Phase 2c plan before coding".
+- Add a row to **Completed plans**: `| Phase 2b | 2026-06-12-phase-2b-domain-job-income.md | complete |`.
+- Set this plan's header `**Status:**` to `complete`.
+
+- [ ] **Step 3: Run the full suite and linters**
+
+Run: `make`
+Expected: lint + all package tests pass (`core`, `domain`, `simulation`, `web`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/domain/OVERVIEW.md docs/superpowers/plans/2026-06-12-rebuild-index.md docs/superpowers/plans/2026-06-12-phase-2b-domain-job-income.md
+git commit -m "docs: mark Phase 2b job income complete"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Job/SabbaticalWindow models (Task 1) · `PersonHousehold.jobs` + persistence (Task 2) · `boundary_to_year_month` + `month_boundary` + `index_of` reuse (Task 3) · `Household` window validator with no-`today` resolution and open-bound tolerance (Task 4) · segment compilation with re-anchoring (Task 5) · per-person `gross`/`ss_covered_gross`/`tax_deferred` + household totals, uncapped SS, fraction tax-deferred, divide-by-zero guard (Task 6) · OVERVIEW + index (Task 7).
+- **No system-level retirement state** — never introduced; "no income" is just zeros.
+- **Type consistency:** `compile_job_to_streams(job, timeline)`, `project_job_income(plan, timeline)`, `JobIncomeProjection.person{1,2}` / `total_*`, `PersonJobIncome.{gross,ss_covered_gross,tax_deferred}`, `boundary_to_year_month(boundary, household)`, `Timeline.month_boundary(index)` are used identically across tasks.
+- **Circular import:** `core.models.Household` validator imports `boundary_to_year_month` locally (function body), since `core.timeline` imports `core.models` at module load.
+
+---
+
+## Execution handoff
+
+Implement via **superpowers:subagent-driven-development** (recommended) — one subagent per task, review between tasks — or **superpowers:executing-plans** for batched inline execution.

--- a/docs/superpowers/plans/2026-06-12-phase-2b-domain-job-income.md
+++ b/docs/superpowers/plans/2026-06-12-phase-2b-domain-job-income.md
@@ -2,34 +2,37 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Port legacy job income onto the Phase 2a `TimedStream` foundation — multiple jobs per person, each with per-job sabbatical windows (full break or % reduction), projected into per-person month-indexed series for Phase 2c/2d.
+**Goal:** Port legacy job income onto the Phase 2a `TimedStream` foundation: per-person multiple jobs with raises and per-job sabbatical windows, compiled into month-indexed `JobIncomeProjection` series for downstream phases.
 
-**Architecture:** Config models (`Job`, `SabbaticalWindow`) live in `core` and persist on `PersonHousehold.jobs`. A `Household` Pydantic validator enforces sabbatical-window structure using birth-date-only boundary resolution. The `domain.job_income` package compiles each job into re-anchored `TimedStream` segments (reusing `core.timeline.project_stream`) and aggregates them into a `JobIncomeProjection`.
+**Architecture:** Config models (`Job`, `SabbaticalWindow`) live in `core` and persist on `PersonHousehold.jobs` via the existing JSON-blob repository. Sabbatical-window structure is validated by a `Household` Pydantic validator using a birth-date-only boundary resolver (no `today`). The `domain.job_income` package compiles each job into re-anchored `TimedStream` segments, reuses `core.timeline.project_stream` for growth, and aggregates per-person `gross` / `ss_covered_gross` / `tax_deferred` plus household totals.
 
-**Tech Stack:** Python 3.14, Pydantic v2, `Decimal`, pytest, uv workspace. Run all commands from the repo root `/Users/chris/Projects/life-finances-workspace/LifeFInances`.
+**Tech Stack:** Python 3.14, Pydantic v2, `Decimal` money math, pytest, uv workspace. Spec: `docs/superpowers/specs/2026-06-12-phase-2b-domain-job-income-design.md`.
 
-**Status:** in progress
-
-**Spec:** [`docs/superpowers/specs/2026-06-12-phase-2b-domain-job-income-design.md`](../specs/2026-06-12-phase-2b-domain-job-income-design.md)
+**Conventions for every task:**
+- Follow TDD: write the behavior test, scaffold to a *logical* red (`NotImplementedError`/stub), confirm the failure is logical (not `ImportError`/`AttributeError`), implement, confirm green.
+- Inject `today: date`; never read wall-clock time in logic or assertions.
+- Bind shared values to a variable referenced in both arrange and assert; import constants/defaults from source instead of copying literals.
+- Run developer commands from the **repository root** (`LifeFInances/`).
+- Single test: `uv run pytest <path>::<test_name> -v`. Each task's final commit triggers the pre-commit hook which runs `make` (full build + lint + test).
 
 ---
 
-## File structure
+## File Structure
 
-| File | Responsibility |
-|------|----------------|
-| `packages/core/core/job.py` (new) | `Job`, `SabbaticalWindow` config models + `Job`-level validator |
-| `packages/core/core/models.py` (modify) | `PersonHousehold.jobs`; `Household` sabbatical-window validator |
-| `packages/core/core/timeline.py` (modify) | `boundary_to_year_month` resolver; `Timeline.month_boundary`; `index_of` reuses resolver |
-| `packages/domain/domain/job_income/__init__.py` (new) | `project_job_income`, `JobIncomeProjection`, `PersonJobIncome` |
-| `packages/domain/domain/job_income/compile.py` (new) | `compile_job_to_streams` (segment split + re-anchoring) |
-| `packages/core/tests/test_job.py` (new) | `Job` + `Household` validation, repository round-trip |
-| `packages/core/tests/test_timeline.py` (modify) | `boundary_to_year_month`, `month_boundary` |
-| `packages/domain/tests/test_job_income.py` (new) | compiler + projection behavior |
-| `packages/domain/OVERVIEW.md` (modify) | job-income port status |
-| `docs/superpowers/plans/2026-06-12-rebuild-index.md` (modify) | mark Phase 2b complete |
+**`packages/core/`**
+- `core/job.py` *(new)* — `Job`, `SabbaticalWindow` models + `Job` model-level validator (`annual_tax_deferred <= annual_income`).
+- `core/models.py` *(modify)* — add `PersonHousehold.jobs`; add `Household` sabbatical-window validator.
+- `core/timeline.py` *(modify)* — add `boundary_to_year_month()`; refactor `Timeline.index_of` to reuse it; add `Timeline.month_boundary()`; move the `core.models` import under `TYPE_CHECKING` to break the new `models → timeline` cycle.
+- `tests/test_job.py` *(new)* — `Job` validation, `Household` window validation, repository round-trip.
+- `tests/test_timeline.py` *(modify)* — `boundary_to_year_month` + `month_boundary` behavior.
 
-**Build order:** Task 1 (models) → Task 2 (wire + persist) → Task 3 (resolver/helpers) → Task 4 (Household validator) → Task 5 (compiler) → Task 6 (projection) → Task 7 (docs + green).
+**`packages/domain/`**
+- `domain/job_income/__init__.py` *(new)* — `PersonJobIncome`, `JobIncomeProjection`, `project_job_income()`.
+- `domain/job_income/compile.py` *(new)* — `project_job_gross()` (segment split + re-anchoring + projection).
+- `tests/test_job_income.py` *(new)* — compilation and projection behaviors.
+- `OVERVIEW.md` *(modify)* — job-income port status.
+
+**`docs/superpowers/plans/2026-06-12-rebuild-index.md`** *(modify)* — active-phase pointer at the end.
 
 ---
 
@@ -41,59 +44,44 @@
 
 - [ ] **Step 1: Write the failing test**
 
-Create `packages/core/tests/test_job.py`:
-
 ```python
+# packages/core/tests/test_job.py
 from __future__ import annotations
 
 from decimal import Decimal
 
 import pytest
-from core.job import Job, SabbaticalWindow
-from core.streams import CalendarMonthBoundary
 from pydantic import ValidationError
+
+from core.job import Job
 
 
 def test_job_rejects_tax_deferred_above_income() -> None:
     income = Decimal("100000")
-    too_much = income + Decimal("1")
+    too_much_deferred = income + Decimal("1")
 
     with pytest.raises(ValidationError):
-        Job(annual_income=income, annual_tax_deferred=too_much)
+        Job(annual_income=income, annual_tax_deferred=too_much_deferred)
 
 
 def test_job_allows_tax_deferred_equal_to_income() -> None:
-    income = Decimal("80000")
+    income = Decimal("100000")
 
     job = Job(annual_income=income, annual_tax_deferred=income)
 
     assert job.annual_tax_deferred == income
-
-
-def test_sabbatical_window_rejects_remaining_fraction_above_one() -> None:
-    with pytest.raises(ValidationError):
-        SabbaticalWindow(
-            start=CalendarMonthBoundary(year=2030, month=1),
-            end=CalendarMonthBoundary(year=2030, month=6),
-            remaining_fraction=Decimal("1.5"),
-        )
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Scaffold to a logical red**
 
-Run: `uv run pytest packages/core/tests/test_job.py -v`
-Expected: FAIL with `ModuleNotFoundError: No module named 'core.job'`. If so, add the empty scaffold below and re-run; expected next failure is logical (`ValidationError` not raised). Confirm the failure is logical before implementing.
-
-- [ ] **Step 3: Write minimal implementation**
-
-Create `packages/core/core/job.py`:
+Create `packages/core/core/job.py` with the models but a deliberately wrong/missing cross-field check so the first test fails on assertion, not import:
 
 ```python
 from __future__ import annotations
 
 from decimal import Decimal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 
 from core.streams import Boundary
 
@@ -101,10 +89,9 @@ from core.streams import Boundary
 class SabbaticalWindow(BaseModel):
     """A window over which a job's pay is reduced (or fully paused).
 
-    `remaining_fraction` is the share of pay still earned: 0 => full break,
+    remaining_fraction is the share of pay still earned: 0 => full break,
     0.5 => half pay, 1 => no reduction. The job's underlying raise clock keeps
     running across the window, so the person returns at the grown salary.
-    Window ordering / overlap / containment is validated on `Household`.
     """
 
     start: Boundary
@@ -113,10 +100,10 @@ class SabbaticalWindow(BaseModel):
 
 
 class Job(BaseModel):
-    """One job held by a person, modeled as a real (today's-dollar) income source.
+    """One job held by a person, as a real (today's-dollar) income source.
 
-    Amounts are annual; the domain compiles them to a monthly stream.
-    `annual_raise` is a REAL raise (growth above inflation). Inflation is never
+    Amounts are annual; the domain compiles them to a monthly TimedStream.
+    annual_raise is a REAL raise (growth above inflation). Inflation is never
     applied here.
     """
 
@@ -128,20 +115,35 @@ class Job(BaseModel):
     end: Boundary | None = None
     social_security_eligible: bool = True
     sabbaticals: list[SabbaticalWindow] = Field(default_factory=list)
+```
 
+- [ ] **Step 3: Run test to verify it fails logically**
+
+Run: `uv run pytest packages/core/tests/test_job.py::test_job_rejects_tax_deferred_above_income -v`
+Expected: FAIL — `DID NOT RAISE ValidationError` (logical, not an import error).
+
+- [ ] **Step 4: Implement the cross-field validator**
+
+Add to `Job` in `packages/core/core/job.py`:
+
+```python
+from pydantic import BaseModel, Field, model_validator
+```
+
+```python
     @model_validator(mode="after")
-    def _tax_deferred_within_income(self) -> Job:
+    def _tax_deferred_within_income(self) -> "Job":
         if self.annual_tax_deferred > self.annual_income:
             raise ValueError("annual_tax_deferred must not exceed annual_income")
         return self
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Run both tests to verify they pass**
 
 Run: `uv run pytest packages/core/tests/test_job.py -v`
-Expected: PASS (3 tests).
+Expected: PASS (2 passed).
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add packages/core/core/job.py packages/core/tests/test_job.py
@@ -150,64 +152,68 @@ git commit -m "feat(core): add Job and SabbaticalWindow config models"
 
 ---
 
-## Task 2: Wire `PersonHousehold.jobs` and prove SQLite round-trip
+## Task 2: Persist `jobs` on `PersonHousehold`
 
 **Files:**
 - Modify: `packages/core/core/models.py`
-- Test: `packages/core/tests/test_repository.py`
+- Test: `packages/core/tests/test_job.py`
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing round-trip test**
 
-Add to `packages/core/tests/test_repository.py`:
+Append to `packages/core/tests/test_job.py`:
 
 ```python
-def test_round_trip_preserves_person_jobs(repo: PlanRepository) -> None:
-    from decimal import Decimal
+from datetime import date
 
-    from core.job import Job, SabbaticalWindow
-    from core.streams import CalendarMonthBoundary
+from core.defaults import default_plan
+from core.repository import PlanRepository
+from core.streams import CalendarMonthBoundary
 
+
+def test_plan_with_jobs_round_trips_through_repository(repo: PlanRepository) -> None:
     plan_id, plan = repo.get_or_create_default()
-    expected_income = Decimal("123456.78")
+    annual_income = Decimal("120000")
     job = Job(
         label="Engineer",
-        annual_income=expected_income,
+        annual_income=annual_income,
         annual_tax_deferred=Decimal("23000"),
         annual_raise=Decimal("0.03"),
+        end=CalendarMonthBoundary(year=date.today().year + 30, month=1),
         sabbaticals=[
             SabbaticalWindow(
-                start=CalendarMonthBoundary(year=2032, month=1),
-                end=CalendarMonthBoundary(year=2032, month=12),
+                start=CalendarMonthBoundary(year=date.today().year + 5, month=1),
+                end=CalendarMonthBoundary(year=date.today().year + 5, month=12),
                 remaining_fraction=Decimal("0.5"),
             )
         ],
     )
-    plan.household.person1.jobs = [job]
+    plan.household.person1.jobs.append(job)
 
     repo.save(plan_id, plan)
-    loaded = repo.get_by_id(plan_id)
+    reloaded = repo.get_by_id(plan_id)
 
-    assert loaded is not None
-    loaded_job = loaded.household.person1.jobs[0]
-    assert loaded_job.annual_income == expected_income
-    assert loaded_job.sabbaticals[0].remaining_fraction == Decimal("0.5")
-    assert isinstance(loaded_job.sabbaticals[0].start, CalendarMonthBoundary)
+    assert reloaded is not None
+    assert reloaded.household.person1.jobs == plan.household.person1.jobs
+    assert reloaded.household.person1.jobs[0].annual_income == annual_income
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+> The `repo` fixture comes from the repo-root `conftest.py`.
 
-Run: `uv run pytest packages/core/tests/test_repository.py::test_round_trip_preserves_person_jobs -v`
-Expected: FAIL — logical failure setting `.jobs` (Pydantic `ValueError` "object has no field 'jobs'") because `PersonHousehold` has no `jobs` field yet.
+- [ ] **Step 2: Run test to verify it fails logically**
 
-- [ ] **Step 3: Write minimal implementation**
+Run: `uv run pytest packages/core/tests/test_job.py::test_plan_with_jobs_round_trips_through_repository -v`
+Expected: FAIL — `AttributeError: 'PersonHousehold' object has no attribute 'jobs'` is structural; if you see it, that is the cue to add the field (Step 3), then it should fail logically only if the field is wrong. (Adding the field is minimal scaffolding here.)
 
-Modify `packages/core/core/models.py`. Add the import and the field:
+- [ ] **Step 3: Add the field**
+
+Modify `packages/core/core/models.py`:
 
 ```python
 from core.job import Job
 from core.streams import TimedStream
+```
 
-
+```python
 class PersonHousehold(BaseModel):
     birth_month: int = Field(ge=1, le=12)
     birth_year: int
@@ -215,74 +221,106 @@ class PersonHousehold(BaseModel):
     jobs: list[Job] = Field(default_factory=list)
 ```
 
-(Keep the existing `Household`, `Portfolio`, `Plan` classes unchanged in this task.)
-
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `uv run pytest packages/core/tests/test_repository.py -v`
-Expected: PASS (all repository tests).
+Run: `uv run pytest packages/core/tests/test_job.py::test_plan_with_jobs_round_trips_through_repository -v`
+Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Confirm default plan + existing core tests still pass**
+
+Run: `uv run pytest packages/core -v`
+Expected: PASS (all green, including existing `test_repository`, `test_streams`, `test_timeline`).
+
+- [ ] **Step 6: Commit**
 
 ```bash
-git add packages/core/core/models.py packages/core/tests/test_repository.py
-git commit -m "feat(core): persist per-person jobs on PersonHousehold"
+git add packages/core/core/models.py packages/core/tests/test_job.py
+git commit -m "feat(core): persist jobs on PersonHousehold"
 ```
 
 ---
 
-## Task 3: `boundary_to_year_month` resolver + `Timeline.month_boundary`
+## Task 3: `boundary_to_year_month` resolver + break the import cycle
 
 **Files:**
 - Modify: `packages/core/core/timeline.py`
 - Test: `packages/core/tests/test_timeline.py`
 
-- [ ] **Step 1: Write the failing test**
+**Why:** The `Household` validator (Task 5) must resolve any boundary to an absolute `(year, month)` using birth dates only. That logic belongs in `core.timeline` and must be importable from `core.models` — so `timeline`'s runtime import of `core.models` is moved under `TYPE_CHECKING`.
 
-Add to `packages/core/tests/test_timeline.py`:
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/tests/test_timeline.py`:
 
 ```python
 from core.timeline import boundary_to_year_month
 
 
-def test_boundary_to_year_month_resolves_person_age_without_today() -> None:
-    plan = default_plan()
-    person = plan.household.person1
-    age_months = 480  # 40 years
+def test_boundary_to_year_month_calendar_is_identity() -> None:
+    year, month = 2031, 7
 
-    year, month = boundary_to_year_month(
-        PersonAgeBoundary(person="person1", age_months=age_months),
-        plan.household,
+    result = boundary_to_year_month(
+        CalendarMonthBoundary(year=year, month=month), default_plan().household
     )
 
-    assert year == person.birth_year + age_months // 12
-    assert month == person.birth_month
+    assert result == (year, month)
 
 
-def test_month_boundary_is_inverse_of_index_of() -> None:
-    today = date(2026, 6, 1)
-    plan = default_plan()
-    timeline = Timeline(plan, today=today)
-    index = 27
+def test_boundary_to_year_month_person_age_uses_birth_plus_age() -> None:
+    household = default_plan().household
+    person = household.person1
+    age_months = 600  # 50 years
 
-    boundary = timeline.month_boundary(index)
+    result = boundary_to_year_month(
+        PersonAgeBoundary(person="person1", age_months=age_months), household
+    )
 
-    assert timeline.index_of(boundary) == index
+    assert result == (person.birth_year + age_months // 12, person.birth_month)
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Scaffold to a logical red**
 
-Run: `uv run pytest packages/core/tests/test_timeline.py -k "boundary_to_year_month or month_boundary" -v`
-Expected: FAIL with `ImportError` for `boundary_to_year_month`. Add the scaffolds (a `boundary_to_year_month` that returns `(0, 0)` and a `month_boundary` returning `CalendarMonthBoundary(year=0, month=1)`), re-run, confirm the failure is now logical (`AssertionError`) before implementing.
-
-- [ ] **Step 3: Write minimal implementation**
-
-Modify `packages/core/core/timeline.py`. Add the import of `Household` and the resolver, and refactor `index_of` to reuse it; add `month_boundary`:
+In `packages/core/core/timeline.py`, add a stub (keep existing code intact for now):
 
 ```python
-from core.models import Household, PersonHousehold, Plan
+def boundary_to_year_month(boundary: Boundary, household: Household) -> tuple[int, int]:
+    raise NotImplementedError
+```
 
+> `Household` is only referenced in the annotation; with `from __future__ import annotations` it is a string at runtime.
 
+- [ ] **Step 3: Run tests to verify logical failure**
+
+Run: `uv run pytest packages/core/tests/test_timeline.py::test_boundary_to_year_month_calendar_is_identity -v`
+Expected: FAIL with `NotImplementedError` (logical).
+
+- [ ] **Step 4: Implement the resolver, refactor `index_of`, and move the import**
+
+In `packages/core/core/timeline.py`:
+
+1. Replace the top-of-file `core.models` import with a `TYPE_CHECKING` block:
+
+```python
+from __future__ import annotations
+
+from datetime import date
+from decimal import ROUND_HALF_UP, Decimal
+from typing import TYPE_CHECKING
+
+from core.streams import (
+    Boundary,
+    CalendarMonthBoundary,
+    PersonAgeBoundary,
+    TimedStream,
+)
+
+if TYPE_CHECKING:
+    from core.models import Household, PersonHousehold, Plan
+```
+
+2. Implement the resolver:
+
+```python
 def boundary_to_year_month(boundary: Boundary, household: Household) -> tuple[int, int]:
     """Resolve a boundary to an absolute (year, month). Birth-date only; no `today`."""
     if isinstance(boundary, CalendarMonthBoundary):
@@ -293,7 +331,7 @@ def boundary_to_year_month(boundary: Boundary, household: Household) -> tuple[in
     raise TypeError(f"Unknown boundary: {boundary!r}")
 ```
 
-Replace the body of `Timeline.index_of` with:
+3. Refactor `Timeline.index_of` to delegate:
 
 ```python
     def index_of(self, boundary: Boundary) -> int:
@@ -301,7 +339,57 @@ Replace the body of `Timeline.index_of` with:
         return self._offset(year, month)
 ```
 
-Add to `Timeline`:
+- [ ] **Step 5: Run timeline + full core tests**
+
+Run: `uv run pytest packages/core/tests/test_timeline.py -v`
+Then: `uv run pytest packages/core -v`
+Expected: PASS (existing `index_of` tests still pass via the delegated path).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/core/timeline.py packages/core/tests/test_timeline.py
+git commit -m "feat(core): add boundary_to_year_month resolver and reuse in index_of"
+```
+
+---
+
+## Task 4: `Timeline.month_boundary` (inverse of the offset)
+
+**Files:**
+- Modify: `packages/core/core/timeline.py`
+- Test: `packages/core/tests/test_timeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/core/tests/test_timeline.py`:
+
+```python
+def test_month_boundary_is_inverse_of_index_of() -> None:
+    timeline = Timeline(default_plan(), today=date(2026, 6, 1))
+    index = 19
+
+    boundary = timeline.month_boundary(index)
+
+    assert isinstance(boundary, CalendarMonthBoundary)
+    assert timeline.index_of(boundary) == index
+```
+
+- [ ] **Step 2: Scaffold to a logical red**
+
+Add to the `Timeline` class:
+
+```python
+    def month_boundary(self, index: int) -> CalendarMonthBoundary:
+        raise NotImplementedError
+```
+
+- [ ] **Step 3: Run test to verify logical failure**
+
+Run: `uv run pytest packages/core/tests/test_timeline.py::test_month_boundary_is_inverse_of_index_of -v`
+Expected: FAIL with `NotImplementedError`.
+
+- [ ] **Step 4: Implement**
 
 ```python
     def month_boundary(self, index: int) -> CalendarMonthBoundary:
@@ -310,84 +398,133 @@ Add to `Timeline`:
         return CalendarMonthBoundary(year=year, month=month)
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Run test to verify it passes**
 
-Run: `uv run pytest packages/core/tests/test_timeline.py -v`
-Expected: PASS (existing + 2 new tests; `index_of` tests still green after refactor).
+Run: `uv run pytest packages/core/tests/test_timeline.py::test_month_boundary_is_inverse_of_index_of -v`
+Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add packages/core/core/timeline.py packages/core/tests/test_timeline.py
-git commit -m "feat(core): add boundary_to_year_month resolver and Timeline.month_boundary"
+git commit -m "feat(core): add Timeline.month_boundary"
 ```
 
 ---
 
-## Task 4: `Household` sabbatical-window validator
+## Task 5: `Household` sabbatical-window validator
 
 **Files:**
 - Modify: `packages/core/core/models.py`
 - Test: `packages/core/tests/test_job.py`
 
-- [ ] **Step 1: Write the failing test**
+**Behavior:** For each person's each job, resolve boundaries to absolute `year*12 + month` and require: each window `start <= end`; windows strictly ordered and non-overlapping (`next.start > prev.end`, inclusive months); each window within the job's **explicit** bounds (open `None` bounds are not enforced).
 
-Add to `packages/core/tests/test_job.py`:
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/tests/test_job.py`:
 
 ```python
-from core.models import Household, PersonHousehold
+from core.models import Household, PersonHousehold, Plan, Portfolio
+from core.streams import PersonAgeBoundary
 
 
-def _person(birth_year: int, jobs: list[Job]) -> PersonHousehold:
-    return PersonHousehold(birth_month=1, birth_year=birth_year, jobs=jobs)
-
-
-def _window(start_month: int, end_month: int, remaining: str = "0") -> SabbaticalWindow:
-    return SabbaticalWindow(
-        start=CalendarMonthBoundary(year=2030, month=start_month),
-        end=CalendarMonthBoundary(year=2030, month=end_month),
-        remaining_fraction=Decimal(remaining),
+def _household_with_person1_jobs(jobs: list[Job]) -> Household:
+    return Household(
+        person1=PersonHousehold(birth_month=1, birth_year=1980, jobs=jobs),
+        person2=PersonHousehold(birth_month=1, birth_year=1982),
     )
 
 
-def test_household_rejects_overlapping_sabbatical_windows() -> None:
-    job = Job(annual_income=Decimal("100000"), sabbaticals=[_window(1, 6), _window(5, 9)])
-
-    with pytest.raises(ValidationError):
-        Household(person1=_person(1980, [job]), person2=_person(1982, []))
-
-
-def test_household_rejects_window_outside_explicit_job_bounds() -> None:
+def test_overlapping_windows_rejected() -> None:
     job = Job(
         annual_income=Decimal("100000"),
-        start=CalendarMonthBoundary(year=2030, month=3),
-        end=CalendarMonthBoundary(year=2030, month=8),
-        sabbaticals=[_window(1, 4)],  # starts before job start
+        sabbaticals=[
+            SabbaticalWindow(
+                start=CalendarMonthBoundary(year=2030, month=1),
+                end=CalendarMonthBoundary(year=2030, month=6),
+                remaining_fraction=Decimal("0.5"),
+            ),
+            SabbaticalWindow(
+                start=CalendarMonthBoundary(year=2030, month=6),
+                end=CalendarMonthBoundary(year=2030, month=12),
+                remaining_fraction=Decimal("0"),
+            ),
+        ],
     )
 
     with pytest.raises(ValidationError):
-        Household(person1=_person(1980, [job]), person2=_person(1982, []))
+        _household_with_person1_jobs([job])
 
 
-def test_household_accepts_ordered_in_bounds_windows() -> None:
-    job = Job(annual_income=Decimal("100000"), sabbaticals=[_window(1, 3), _window(5, 7)])
+def test_window_outside_explicit_job_bounds_rejected() -> None:
+    job = Job(
+        annual_income=Decimal("100000"),
+        start=CalendarMonthBoundary(year=2030, month=1),
+        end=CalendarMonthBoundary(year=2035, month=12),
+        sabbaticals=[
+            SabbaticalWindow(
+                start=CalendarMonthBoundary(year=2029, month=1),
+                end=CalendarMonthBoundary(year=2029, month=6),
+                remaining_fraction=Decimal("0"),
+            )
+        ],
+    )
 
-    household = Household(person1=_person(1980, [job]), person2=_person(1982, []))
+    with pytest.raises(ValidationError):
+        _household_with_person1_jobs([job])
 
-    assert household.person1.jobs[0].sabbaticals[1].start.month == 5
+
+def test_window_against_open_bound_is_accepted() -> None:
+    job = Job(
+        annual_income=Decimal("100000"),
+        sabbaticals=[
+            SabbaticalWindow(
+                start=PersonAgeBoundary(person="person1", age_months=720),
+                end=PersonAgeBoundary(person="person1", age_months=732),
+                remaining_fraction=Decimal("0"),
+            )
+        ],
+    )
+
+    household = _household_with_person1_jobs([job])
+
+    assert household.person1.jobs[0].sabbaticals[0].remaining_fraction == Decimal("0")
+
+
+def test_cross_person_and_mixed_boundary_kinds_resolve() -> None:
+    # window bounded by a calendar start and person2's age — both must resolve
+    job = Job(
+        annual_income=Decimal("100000"),
+        sabbaticals=[
+            SabbaticalWindow(
+                start=CalendarMonthBoundary(year=2030, month=1),
+                end=PersonAgeBoundary(person="person2", age_months=720),  # person2 born 1982 -> 2042
+                remaining_fraction=Decimal("0.5"),
+            )
+        ],
+    )
+
+    household = _household_with_person1_jobs([job])
+
+    assert len(household.person1.jobs[0].sabbaticals) == 1
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Scaffold to a logical red**
 
-Run: `uv run pytest packages/core/tests/test_job.py -k household -v`
-Expected: FAIL — logical failure: the two "reject" tests do not raise `ValidationError` because no `Household` validator exists yet.
-
-- [ ] **Step 3: Write minimal implementation**
-
-Modify `packages/core/core/models.py`. Add a `model_validator(mode="after")` to `Household` (import `model_validator` from pydantic). The `boundary_to_year_month` import is local to avoid a circular import with `core.timeline`:
+Add the validator skeleton + helper to `packages/core/core/models.py` (import the resolver — now safe per Task 3):
 
 ```python
 from pydantic import BaseModel, Field, model_validator
+
+from core.job import Job
+from core.streams import TimedStream
+from core.timeline import boundary_to_year_month
+```
+
+```python
+def _validate_job_windows(job: "Job", household: "Household") -> None:
+    raise NotImplementedError
 
 
 class Household(BaseModel):
@@ -396,38 +533,50 @@ class Household(BaseModel):
 
     @model_validator(mode="after")
     def _validate_sabbatical_windows(self) -> "Household":
-        from core.timeline import boundary_to_year_month
-
-        def abs_month(boundary) -> int:
-            year, month = boundary_to_year_month(boundary, self)
-            return year * 12 + (month - 1)
-
         for person in (self.person1, self.person2):
             for job in person.jobs:
-                job_lo = abs_month(job.start) if job.start is not None else None
-                job_hi = abs_month(job.end) if job.end is not None else None
-                prev_end: int | None = None
-                for window in job.sabbaticals:
-                    start = abs_month(window.start)
-                    end = abs_month(window.end)
-                    if start > end:
-                        raise ValueError("sabbatical window start must not be after end")
-                    if job_lo is not None and start < job_lo:
-                        raise ValueError("sabbatical window starts before job start")
-                    if job_hi is not None and end > job_hi:
-                        raise ValueError("sabbatical window ends after job end")
-                    if prev_end is not None and start <= prev_end:
-                        raise ValueError("sabbatical windows must be ordered and non-overlapping")
-                    prev_end = end
+                _validate_job_windows(job, self)
         return self
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 3: Run tests to verify logical failure**
+
+Run: `uv run pytest packages/core/tests/test_job.py::test_window_against_open_bound_is_accepted -v`
+Expected: FAIL — `NotImplementedError` wrapped in `ValidationError` (logical). The two "rejected" tests will pass for the wrong reason at this point; the accepting/resolving tests prove the implementation in Step 5.
+
+- [ ] **Step 4: Implement `_validate_job_windows`**
+
+```python
+def _validate_job_windows(job: "Job", household: "Household") -> None:
+    def absolute(boundary) -> int:
+        year, month = boundary_to_year_month(boundary, household)
+        return year * 12 + month
+
+    low = absolute(job.start) if job.start is not None else None
+    high = absolute(job.end) if job.end is not None else None
+
+    previous_end: int | None = None
+    for window in job.sabbaticals:
+        start = absolute(window.start)
+        end = absolute(window.end)
+        if start > end:
+            raise ValueError("sabbatical window start must not be after its end")
+        if low is not None and start < low:
+            raise ValueError("sabbatical window starts before the job's start")
+        if high is not None and end > high:
+            raise ValueError("sabbatical window ends after the job's end")
+        if previous_end is not None and start <= previous_end:
+            raise ValueError("sabbatical windows must be ordered and non-overlapping")
+        previous_end = end
+```
+
+- [ ] **Step 5: Run the window tests and full core suite**
 
 Run: `uv run pytest packages/core/tests/test_job.py -v`
-Expected: PASS (all `Job` + `Household` tests).
+Then: `uv run pytest packages/core -v`
+Expected: PASS (all). Confirm `test_window_against_open_bound_is_accepted` and `test_cross_person_and_mixed_boundary_kinds_resolve` now pass via real logic.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add packages/core/core/models.py packages/core/tests/test_job.py
@@ -436,18 +585,19 @@ git commit -m "feat(core): validate sabbatical windows on Household"
 
 ---
 
-## Task 5: Compile a `Job` into re-anchored `TimedStream` segments
+## Task 6: Compile a job into a projected gross series
 
 **Files:**
-- Create: `packages/domain/domain/job_income/__init__.py`
+- Create: `packages/domain/domain/job_income/__init__.py` (empty package marker for now — a docstring only)
 - Create: `packages/domain/domain/job_income/compile.py`
 - Test: `packages/domain/tests/test_job_income.py`
 
-- [ ] **Step 1: Write the failing test**
+**Approach:** Split the job window at sabbatical boundaries into `(start_index, end_index, remaining_fraction)` segments (full between/around windows, reduced inside). Each segment is a `TimedStream` whose `monthly_amount` is the **un-quantized** re-anchored base `base_monthly * remaining * (1 + raise) ** ((segment_start - job_start) / 12)`; `project_stream` then applies within-segment growth and the single cents rounding. Disjoint segment series are summed to the job's gross.
 
-Create `packages/domain/tests/test_job_income.py`:
+- [ ] **Step 1: Write the failing tests**
 
 ```python
+# packages/domain/tests/test_job_income.py
 from __future__ import annotations
 
 from datetime import date
@@ -455,97 +605,89 @@ from decimal import Decimal
 
 from core.defaults import default_plan
 from core.job import Job, SabbaticalWindow
-from core.streams import CalendarMonthBoundary
-from core.timeline import Timeline, project_stream
-from domain.job_income.compile import compile_job_to_streams
+from core.streams import CalendarMonthBoundary, TimedStream
+from core.timeline import Timeline, add_months, project_stream
+
+from domain.job_income.compile import project_job_gross
 
 
 def _timeline() -> Timeline:
     return Timeline(default_plan(), today=date(2026, 1, 1))
 
 
-def _project(job: Job, timeline: Timeline) -> list[Decimal]:
-    horizon = timeline.horizon_months
-    totals = [Decimal("0.00")] * horizon
-    for stream in compile_job_to_streams(job, timeline):
-        for index, value in enumerate(project_stream(stream, timeline)):
-            totals[index] += value
-    return totals
-
-
-def test_single_job_converts_annual_to_monthly() -> None:
+def test_single_job_matches_growth_curve() -> None:
     timeline = _timeline()
-    annual = Decimal("120000")
-    job = Job(annual_income=annual)
-
-    series = _project(job, timeline)
-
-    assert series[0] == (annual / 12).quantize(Decimal("0.01"))
-
-
-def test_full_break_resumes_on_the_no_break_growth_curve() -> None:
-    timeline = _timeline()
-    annual = Decimal("120000")
+    annual_income = Decimal("120000")
     rate = Decimal("0.12")
-    break_start, break_end = 12, 23
-    resume_index = break_end + 1
-    windowed = Job(
-        annual_income=annual,
+    job = Job(annual_income=annual_income, annual_raise=rate)
+
+    gross = project_job_gross(job, timeline)
+
+    reference = project_stream(
+        TimedStream(monthly_amount=annual_income / Decimal(12), annual_growth_rate=rate),
+        timeline,
+    )
+    assert gross == reference
+
+
+def test_full_break_zeroes_window_and_resumes_on_curve() -> None:
+    timeline = _timeline()
+    annual_income = Decimal("120000")
+    rate = Decimal("0.12")
+    break_start_index = 12
+    break_end_index = 23
+    resume_index = break_end_index + 1
+    start_y, start_m = add_months(timeline.today.year, timeline.today.month, break_start_index)
+    end_y, end_m = add_months(timeline.today.year, timeline.today.month, break_end_index)
+    job = Job(
+        annual_income=annual_income,
         annual_raise=rate,
         sabbaticals=[
             SabbaticalWindow(
-                start=timeline.month_boundary(break_start),
-                end=timeline.month_boundary(break_end),
+                start=CalendarMonthBoundary(year=start_y, month=start_m),
+                end=CalendarMonthBoundary(year=end_y, month=end_m),
                 remaining_fraction=Decimal("0"),
             )
         ],
     )
-    continuous = Job(annual_income=annual, annual_raise=rate)
 
-    windowed_series = _project(windowed, timeline)
-    continuous_series = _project(continuous, timeline)
+    gross = project_job_gross(job, timeline)
 
-    assert windowed_series[break_start] == Decimal("0.00")
-    assert windowed_series[resume_index] == continuous_series[resume_index]
+    no_break = project_job_gross(Job(annual_income=annual_income, annual_raise=rate), timeline)
+    assert gross[break_start_index] == Decimal("0.00")
+    assert gross[break_end_index] == Decimal("0.00")
+    assert gross[resume_index] == no_break[resume_index]
 
 
-def test_partial_reduction_scales_grown_amount() -> None:
+def test_partial_reduction_scales_window() -> None:
     timeline = _timeline()
-    annual = Decimal("120000")
-    rate = Decimal("0.12")
+    annual_income = Decimal("120000")
     remaining = Decimal("0.5")
-    reduce_at = 12
-    reduced = Job(
-        annual_income=annual,
-        annual_raise=rate,
+    window_index = 6
+    win_y, win_m = add_months(timeline.today.year, timeline.today.month, window_index)
+    job = Job(
+        annual_income=annual_income,
         sabbaticals=[
             SabbaticalWindow(
-                start=timeline.month_boundary(reduce_at),
-                end=timeline.month_boundary(reduce_at + 5),
+                start=CalendarMonthBoundary(year=win_y, month=win_m),
+                end=CalendarMonthBoundary(year=win_y, month=win_m),
                 remaining_fraction=remaining,
             )
         ],
     )
-    full = Job(annual_income=annual, annual_raise=rate)
 
-    reduced_series = _project(reduced, timeline)
-    full_series = _project(full, timeline)
+    gross = project_job_gross(job, timeline)
 
-    expected = (full_series[reduce_at] * remaining).quantize(Decimal("0.01"))
-    assert reduced_series[reduce_at] == expected
+    full_monthly = (annual_income / Decimal(12)).quantize(Decimal("0.01"))
+    assert gross[window_index] == (full_monthly * remaining).quantize(Decimal("0.01"))
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `uv run pytest packages/domain/tests/test_job_income.py -v`
-Expected: FAIL with `ModuleNotFoundError: No module named 'domain.job_income'`. Add the package scaffold (empty `__init__.py` and a `compile_job_to_streams` returning `[]`), re-run, and confirm the failure is logical (`AssertionError` / `IndexError`) before implementing.
-
-- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 2: Scaffold to a logical red**
 
 Create `packages/domain/domain/job_income/__init__.py`:
 
 ```python
-"""Job income: compile jobs into timed-stream segments and project them."""
+"""Job income: compile jobs into projected monthly cashflow series."""
 ```
 
 Create `packages/domain/domain/job_income/compile.py`:
@@ -557,142 +699,211 @@ from decimal import Decimal
 
 from core.job import Job
 from core.streams import TimedStream
-from core.timeline import Timeline
+from core.timeline import Timeline, project_stream
+
+_MONTHS_PER_YEAR = Decimal(12)
 
 
-def compile_job_to_streams(job: Job, timeline: Timeline) -> list[TimedStream]:
-    """Split a job into full/reduced `TimedStream` segments.
-
-    Each segment's base is re-anchored to the job's start so the segments stitch
-    into one continuous `base * (1 + raise) ** ((t - job_start) / 12)` curve,
-    scaled by `remaining_fraction` inside sabbatical windows (Phase 2a §6.1).
-    """
-    base_monthly = job.annual_income / Decimal(12)
-    growth_base = Decimal(1) + job.annual_raise
-    job_start_index = 0 if job.start is None else timeline.index_of(job.start)
-    job_end_index = None if job.end is None else timeline.index_of(job.end)
-
-    windows = [
-        (
-            timeline.index_of(window.start),
-            timeline.index_of(window.end),
-            window.remaining_fraction,
-        )
-        for window in job.sabbaticals
-    ]
-
-    streams: list[TimedStream] = []
-
-    def make_segment(start_index: int, end_index: int | None, remaining: Decimal) -> None:
-        exponent = Decimal(start_index - job_start_index) / Decimal(12)
-        segment_base = base_monthly * remaining * (growth_base**exponent)
-        streams.append(
-            TimedStream(
-                monthly_amount=segment_base,
-                start=timeline.month_boundary(start_index),
-                end=None if end_index is None else timeline.month_boundary(end_index),
-                annual_growth_rate=job.annual_raise,
-                is_nominal=False,
-            )
-        )
-
-    cursor = job_start_index
-    for window_start, window_end, remaining in windows:
-        if cursor <= window_start - 1:
-            make_segment(cursor, window_start - 1, Decimal(1))
-        make_segment(window_start, window_end, remaining)
-        cursor = window_end + 1
-
-    if job_end_index is None:
-        make_segment(cursor, None, Decimal(1))
-    elif cursor <= job_end_index:
-        make_segment(cursor, job_end_index, Decimal(1))
-
-    return streams
+def project_job_gross(job: Job, timeline: Timeline) -> list[Decimal]:
+    raise NotImplementedError
 ```
 
-> Note: `monthly_amount` must be `>= 0`; `remaining_fraction` is in `[0, 1]` and the growth factor is positive, so `segment_base >= 0` always holds.
+- [ ] **Step 3: Run tests to verify logical failure**
 
-- [ ] **Step 4: Run test to verify it passes**
+Run: `uv run pytest packages/domain/tests/test_job_income.py::test_single_job_matches_growth_curve -v`
+Expected: FAIL with `NotImplementedError` (logical, not import).
+
+- [ ] **Step 4: Implement the compiler**
+
+Replace `project_job_gross` in `compile.py`:
+
+```python
+def _segments(
+    job: Job, timeline: Timeline, job_start: int, job_end: int
+) -> list[tuple[int, int, Decimal]]:
+    """(start_index, end_index, remaining_fraction) segments covering the job."""
+    segments: list[tuple[int, int, Decimal]] = []
+    cursor = job_start
+    for window in job.sabbaticals:
+        window_start = timeline.index_of(window.start)
+        window_end = timeline.index_of(window.end)
+        if window_start > cursor:
+            segments.append((cursor, window_start - 1, Decimal(1)))
+        segments.append((window_start, window_end, window.remaining_fraction))
+        cursor = window_end + 1
+    if cursor <= job_end:
+        segments.append((cursor, job_end, Decimal(1)))
+    return segments
+
+
+def _segment_stream(
+    base_monthly: Decimal,
+    remaining: Decimal,
+    segment_start: int,
+    job_start: int,
+    growth: Decimal,
+    timeline: Timeline,
+    segment_end: int,
+) -> TimedStream:
+    anchor_exponent = Decimal(segment_start - job_start) / _MONTHS_PER_YEAR
+    segment_base = base_monthly * remaining * (Decimal(1) + growth) ** anchor_exponent
+    return TimedStream(
+        monthly_amount=segment_base,
+        start=timeline.month_boundary(segment_start),
+        end=timeline.month_boundary(segment_end),
+        annual_growth_rate=growth,
+        is_nominal=False,
+    )
+
+
+def project_job_gross(job: Job, timeline: Timeline) -> list[Decimal]:
+    """Project one job to a horizon-length monthly gross series (sabbaticals applied)."""
+    horizon = timeline.horizon_months
+    series = [Decimal("0.00")] * horizon
+    if horizon <= 0:
+        return series
+
+    base_monthly = job.annual_income / _MONTHS_PER_YEAR
+    growth = job.annual_raise
+    job_start = 0 if job.start is None else timeline.index_of(job.start)
+    job_end = horizon - 1 if job.end is None else timeline.index_of(job.end)
+
+    for segment_start, segment_end, remaining in _segments(job, timeline, job_start, job_end):
+        if segment_start > segment_end:
+            continue
+        stream = _segment_stream(
+            base_monthly, remaining, segment_start, job_start, growth, timeline, segment_end
+        )
+        segment_series = project_stream(stream, timeline)
+        for i in range(horizon):
+            series[i] += segment_series[i]
+    return series
+```
+
+- [ ] **Step 5: Run the compile tests + existing domain test**
 
 Run: `uv run pytest packages/domain/tests/test_job_income.py -v`
-Expected: PASS (3 tests).
+Then: `uv run pytest packages/domain -v`
+Expected: PASS (incl. `test_domain_scaffold`). The re-anchoring test passes because `segment_base` is un-quantized — `project_stream` applies the single cents rounding, so the post-break value equals the no-break curve exactly.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add packages/domain/domain/job_income/__init__.py packages/domain/domain/job_income/compile.py packages/domain/tests/test_job_income.py
-git commit -m "feat(domain): compile jobs into re-anchored sabbatical-aware stream segments"
+git commit -m "feat(domain): compile jobs into projected gross series with sabbatical re-anchoring"
 ```
 
 ---
 
-## Task 6: `project_job_income` → `JobIncomeProjection`
+## Task 7: `project_job_income` aggregator + result types
 
 **Files:**
 - Modify: `packages/domain/domain/job_income/__init__.py`
 - Test: `packages/domain/tests/test_job_income.py`
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing tests**
 
-Add to `packages/domain/tests/test_job_income.py`:
+Append to `packages/domain/tests/test_job_income.py`:
 
 ```python
-from domain.job_income import JobIncomeProjection, project_job_income
+from core.models import Household, PersonHousehold, Plan, Portfolio
+
+from domain.job_income import (
+    JobIncomeProjection,
+    PersonJobIncome,
+    project_job_income,
+)
 
 
-def _plan_with_jobs(person1_jobs, person2_jobs):
-    plan = default_plan()
-    plan.household.person1.jobs = person1_jobs
-    plan.household.person2.jobs = person2_jobs
-    return plan
+def _plan_with_jobs(person1_jobs: list[Job], person2_jobs: list[Job]) -> Plan:
+    base = default_plan()
+    return Plan(
+        name=base.name,
+        household=Household(
+            person1=PersonHousehold(
+                birth_month=base.household.person1.birth_month,
+                birth_year=base.household.person1.birth_year,
+                max_age_years=base.household.person1.max_age_years,
+                jobs=person1_jobs,
+            ),
+            person2=PersonHousehold(
+                birth_month=base.household.person2.birth_month,
+                birth_year=base.household.person2.birth_year,
+                max_age_years=base.household.person2.max_age_years,
+                jobs=person2_jobs,
+            ),
+        ),
+        portfolio=base.portfolio,
+    )
 
 
 def test_concurrent_jobs_sum_per_person() -> None:
     timeline = _timeline()
-    job_a = Job(annual_income=Decimal("60000"))
-    job_b = Job(annual_income=Decimal("36000"))
-    plan = _plan_with_jobs([job_a, job_b], [])
+    income_a = Decimal("60000")
+    income_b = Decimal("36000")
+    plan = _plan_with_jobs(
+        [Job(annual_income=income_a), Job(annual_income=income_b)], []
+    )
 
     projection = project_job_income(plan, timeline)
 
-    expected = (Decimal("60000") / 12 + Decimal("36000") / 12).quantize(Decimal("0.01"))
-    assert projection.person1.gross[0] == expected
+    expected_month0 = (
+        income_a / Decimal(12) + income_b / Decimal(12)
+    ).quantize(Decimal("0.01"))
+    assert projection.person1.gross[0] == expected_month0
 
 
-def test_ss_covered_gross_excludes_non_covered_job_and_applies_no_cap() -> None:
+def test_non_ss_covered_job_excluded_from_ss_series() -> None:
     timeline = _timeline()
-    covered = Job(annual_income=Decimal("90000"), social_security_eligible=True)
-    not_covered = Job(annual_income=Decimal("90000"), social_security_eligible=False)
-    plan = _plan_with_jobs([covered, not_covered], [])
+    covered = Decimal("60000")
+    uncovered = Decimal("48000")
+    plan = _plan_with_jobs(
+        [
+            Job(annual_income=covered, social_security_eligible=True),
+            Job(annual_income=uncovered, social_security_eligible=False),
+        ],
+        [],
+    )
 
     projection = project_job_income(plan, timeline)
 
-    covered_monthly = (Decimal("90000") / 12).quantize(Decimal("0.01"))
-    assert projection.person1.gross[0] == covered_monthly * 2
-    assert projection.person1.ss_covered_gross[0] == covered_monthly
+    assert projection.person1.gross[0] == (
+        covered / Decimal(12) + uncovered / Decimal(12)
+    ).quantize(Decimal("0.01"))
+    assert projection.person1.ss_covered_gross[0] == (
+        covered / Decimal(12)
+    ).quantize(Decimal("0.01"))
 
 
-def test_tax_deferred_is_fraction_of_gross() -> None:
+def test_tax_deferred_scales_with_income_fraction() -> None:
     timeline = _timeline()
-    annual_income = Decimal("100000")
-    annual_deferred = Decimal("20000")
-    job = Job(annual_income=annual_income, annual_tax_deferred=annual_deferred)
-    plan = _plan_with_jobs([job], [])
+    income = Decimal("100000")
+    deferred = Decimal("20000")
+    plan = _plan_with_jobs([Job(annual_income=income, annual_tax_deferred=deferred)], [])
 
     projection = project_job_income(plan, timeline)
 
-    fraction = annual_deferred / annual_income
-    expected = (projection.person1.gross[0] * fraction).quantize(Decimal("0.01"))
+    fraction = deferred / income
+    expected = (
+        (income / Decimal(12)).quantize(Decimal("0.01")) * fraction
+    ).quantize(Decimal("0.01"))
     assert projection.person1.tax_deferred[0] == expected
 
 
-def test_household_total_gross_equals_per_person_sum() -> None:
+def test_zero_income_job_has_zero_tax_deferred() -> None:
     timeline = _timeline()
-    plan = _plan_with_jobs(
-        [Job(annual_income=Decimal("60000"))],
-        [Job(annual_income=Decimal("48000"))],
-    )
+    plan = _plan_with_jobs([Job(annual_income=Decimal("0"))], [])
+
+    projection = project_job_income(plan, timeline)
+
+    assert all(value == Decimal("0.00") for value in projection.person1.tax_deferred)
+
+
+def test_household_totals_equal_sum_of_persons() -> None:
+    timeline = _timeline()
+    income1 = Decimal("90000")
+    income2 = Decimal("72000")
+    plan = _plan_with_jobs([Job(annual_income=income1)], [Job(annual_income=income2)])
 
     projection = project_job_income(plan, timeline)
 
@@ -701,27 +912,23 @@ def test_household_total_gross_equals_per_person_sum() -> None:
     )
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Scaffold to a logical red**
 
-Run: `uv run pytest packages/domain/tests/test_job_income.py -k "per_person or covered or tax_deferred or total" -v`
-Expected: FAIL with `ImportError` for `project_job_income` / `JobIncomeProjection`. Add the scaffolds (classes with the listed fields + a `project_job_income` returning a zero-filled projection), re-run, confirm logical failure (`AssertionError`) before implementing.
-
-- [ ] **Step 3: Write minimal implementation**
-
-Replace the contents of `packages/domain/domain/job_income/__init__.py`:
+Replace `packages/domain/domain/job_income/__init__.py` with stubs:
 
 ```python
-"""Job income: compile jobs into timed-stream segments and project them."""
+"""Job income: compile jobs into projected monthly cashflow series."""
 
 from __future__ import annotations
 
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 
-from core.models import PersonHousehold, Plan
-from core.timeline import Timeline, project_stream
 from pydantic import BaseModel
 
-from domain.job_income.compile import compile_job_to_streams
+from core.models import Plan, PersonHousehold
+from core.timeline import Timeline
+
+from domain.job_income.compile import project_job_gross
 
 _CENTS = Decimal("0.01")
 
@@ -732,8 +939,37 @@ class PersonJobIncome(BaseModel):
     tax_deferred: list[Decimal]
 
 
-def _sum(left: list[Decimal], right: list[Decimal]) -> list[Decimal]:
+class JobIncomeProjection(BaseModel):
+    person1: PersonJobIncome
+    person2: PersonJobIncome
+
+
+def project_job_income(plan: Plan, timeline: Timeline) -> JobIncomeProjection:
+    raise NotImplementedError
+```
+
+- [ ] **Step 3: Run tests to verify logical failure**
+
+Run: `uv run pytest packages/domain/tests/test_job_income.py::test_concurrent_jobs_sum_per_person -v`
+Expected: FAIL with `NotImplementedError`.
+
+- [ ] **Step 4: Implement aggregation + totals**
+
+Replace the stub bodies in `__init__.py`:
+
+```python
+def _zeros(length: int) -> list[Decimal]:
+    return [Decimal("0.00")] * length
+
+
+def _add(left: list[Decimal], right: list[Decimal]) -> list[Decimal]:
     return [a + b for a, b in zip(left, right, strict=True)]
+
+
+class PersonJobIncome(BaseModel):
+    gross: list[Decimal]
+    ss_covered_gross: list[Decimal]
+    tax_deferred: list[Decimal]
 
 
 class JobIncomeProjection(BaseModel):
@@ -742,40 +978,34 @@ class JobIncomeProjection(BaseModel):
 
     @property
     def total_gross(self) -> list[Decimal]:
-        return _sum(self.person1.gross, self.person2.gross)
+        return _add(self.person1.gross, self.person2.gross)
 
     @property
     def total_ss_covered_gross(self) -> list[Decimal]:
-        return _sum(self.person1.ss_covered_gross, self.person2.ss_covered_gross)
+        return _add(self.person1.ss_covered_gross, self.person2.ss_covered_gross)
 
     @property
     def total_tax_deferred(self) -> list[Decimal]:
-        return _sum(self.person1.tax_deferred, self.person2.tax_deferred)
+        return _add(self.person1.tax_deferred, self.person2.tax_deferred)
 
 
 def _project_person(person: PersonHousehold, timeline: Timeline) -> PersonJobIncome:
     horizon = timeline.horizon_months
-    gross = [Decimal("0.00")] * horizon
-    ss_covered = [Decimal("0.00")] * horizon
-    tax_deferred = [Decimal("0.00")] * horizon
-
+    gross = _zeros(horizon)
+    ss_covered = _zeros(horizon)
+    tax_deferred = _zeros(horizon)
     for job in person.jobs:
-        fraction = (
-            job.annual_tax_deferred / job.annual_income
-            if job.annual_income
-            else Decimal(0)
-        )
-        job_series = [Decimal("0.00")] * horizon
-        for stream in compile_job_to_streams(job, timeline):
-            for index, value in enumerate(project_stream(stream, timeline)):
-                job_series[index] += value
-        for index in range(horizon):
-            month_gross = job_series[index]
-            gross[index] += month_gross
-            if job.social_security_eligible:
-                ss_covered[index] += month_gross
-            tax_deferred[index] += (month_gross * fraction).quantize(_CENTS)
-
+        job_gross = project_job_gross(job, timeline)
+        gross = _add(gross, job_gross)
+        if job.social_security_eligible:
+            ss_covered = _add(ss_covered, job_gross)
+        if job.annual_income > 0:
+            fraction = job.annual_tax_deferred / job.annual_income
+            job_deferred = [
+                (value * fraction).quantize(_CENTS, rounding=ROUND_HALF_UP)
+                for value in job_gross
+            ]
+            tax_deferred = _add(tax_deferred, job_deferred)
     return PersonJobIncome(
         gross=gross, ss_covered_gross=ss_covered, tax_deferred=tax_deferred
     )
@@ -788,65 +1018,86 @@ def project_job_income(plan: Plan, timeline: Timeline) -> JobIncomeProjection:
     )
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Run domain tests + full core/domain suites**
 
 Run: `uv run pytest packages/domain/tests/test_job_income.py -v`
-Expected: PASS (all compiler + projection tests).
+Then: `uv run pytest packages/core packages/domain -v`
+Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add packages/domain/domain/job_income/__init__.py packages/domain/tests/test_job_income.py
-git commit -m "feat(domain): aggregate jobs into a per-person JobIncomeProjection"
+git commit -m "feat(domain): aggregate per-person and household job income projection"
 ```
 
 ---
 
-## Task 7: Update docs and confirm full green
+## Task 8: Documentation + active-phase pointer + full gate
 
 **Files:**
 - Modify: `packages/domain/OVERVIEW.md`
 - Modify: `docs/superpowers/plans/2026-06-12-rebuild-index.md`
 
-- [ ] **Step 1: Mark the job-income port done in `packages/domain/OVERVIEW.md`**
+- [ ] **Step 1: Update the domain port map**
 
-Change the port-map row:
+In `packages/domain/OVERVIEW.md`, change the job-income row status:
 
 ```markdown
 | `job_income.py` (incl. planned sabbaticals) | `domain/job_income/` | 2b | done |
 ```
 
-- [ ] **Step 2: Update the rebuild index**
+- [ ] **Step 2: Update the rebuild index active phase**
 
-In `docs/superpowers/plans/2026-06-12-rebuild-index.md`:
-- Check the four Phase 2b exit-criteria boxes (`- [x]`).
-- In the **Active phase** table set current phase to `Phase 2c — plan`, active plan to `2026-06-12-phase-2c-domain-social-security.md`, next action to "Write Phase 2c plan before coding".
-- Add a row to **Completed plans**: `| Phase 2b | 2026-06-12-phase-2b-domain-job-income.md | complete |`.
-- Set this plan's header `**Status:**` to `complete`.
+In `docs/superpowers/plans/2026-06-12-rebuild-index.md`, set the Active phase table and check Phase 2b exit criteria:
 
-- [ ] **Step 3: Run the full suite and linters**
+```markdown
+| **Current phase** | Phase 2c — plan |
+| **Active plan** | *(to write)* `2026-06-12-phase-2c-domain-social-security.md` |
+| **Next action** | Write Phase 2c plan before coding |
+```
+
+Tick the Phase 2b exit-criteria checkboxes (`- [x]`) in that file, and add the Phase 2b plan to the "Completed plans" table:
+
+```markdown
+| Phase 2b | `2026-06-12-phase-2b-domain-job-income.md` | complete |
+```
+
+- [ ] **Step 3: Run the full gate**
 
 Run: `make`
-Expected: lint + all package tests pass (`core`, `domain`, `simulation`, `web`).
+Expected: lint + type-check + all tests PASS.
 
 - [ ] **Step 4: Commit**
 
 ```bash
-git add packages/domain/OVERVIEW.md docs/superpowers/plans/2026-06-12-rebuild-index.md docs/superpowers/plans/2026-06-12-phase-2b-domain-job-income.md
-git commit -m "docs: mark Phase 2b job income complete"
+git add packages/domain/OVERVIEW.md docs/superpowers/plans/2026-06-12-rebuild-index.md
+git commit -m "docs: mark Phase 2b job income complete; point index at Phase 2c"
 ```
 
 ---
 
-## Self-review notes
+## Self-Review
 
-- **Spec coverage:** Job/SabbaticalWindow models (Task 1) · `PersonHousehold.jobs` + persistence (Task 2) · `boundary_to_year_month` + `month_boundary` + `index_of` reuse (Task 3) · `Household` window validator with no-`today` resolution and open-bound tolerance (Task 4) · segment compilation with re-anchoring (Task 5) · per-person `gross`/`ss_covered_gross`/`tax_deferred` + household totals, uncapped SS, fraction tax-deferred, divide-by-zero guard (Task 6) · OVERVIEW + index (Task 7).
-- **No system-level retirement state** — never introduced; "no income" is just zeros.
-- **Type consistency:** `compile_job_to_streams(job, timeline)`, `project_job_income(plan, timeline)`, `JobIncomeProjection.person{1,2}` / `total_*`, `PersonJobIncome.{gross,ss_covered_gross,tax_deferred}`, `boundary_to_year_month(boundary, household)`, `Timeline.month_boundary(index)` are used identically across tasks.
-- **Circular import:** `core.models.Household` validator imports `boundary_to_year_month` locally (function body), since `core.timeline` imports `core.models` at module load.
+**Spec coverage (spec §-by-§):**
+- §3 models → Tasks 1, 2. §3 validation (field/Job/Household) → Tasks 1, 5. §3 `boundary_to_year_month` + `index_of` reuse → Task 3.
+- §4 segmented compilation + re-anchoring + `month_boundary` → Tasks 4, 6.
+- §5 `JobIncomeProjection` per-person + totals; uncapped `ss_covered_gross`; tax-deferred fraction (incl. `annual_income==0`) → Task 7.
+- §6 file layout → all tasks. §7 testing table → tests across Tasks 1–7. §8 error handling → Tasks 1, 5, 6. §9 exit criteria → Task 8 + suite. §10 deferred → not implemented (correct).
+
+**Type consistency:** `project_job_gross(job, timeline) -> list[Decimal]` (Task 6) is consumed unchanged in Task 7. `PersonJobIncome` fields `gross` / `ss_covered_gross` / `tax_deferred` and `JobIncomeProjection.person1/person2` + `total_*` properties are consistent between definition (Task 7) and tests. `boundary_to_year_month(boundary, household)` signature matches its caller in `index_of` (Task 3) and `_validate_job_windows` (Task 5). `Timeline.month_boundary(index)` matches usage in `_segment_stream` (Task 6).
+
+**Placeholder scan:** no `TBD`/`TODO`/"handle edge cases"; every code step shows complete code; every test step shows the assertion.
+
+**Import-cycle check:** Task 3 moves `core.models` import in `timeline.py` under `TYPE_CHECKING`, so `core.models` importing `boundary_to_year_month` from `core.timeline` (Task 5) does not create a runtime cycle.
 
 ---
 
-## Execution handoff
+## Execution Handoff
 
-Implement via **superpowers:subagent-driven-development** (recommended) — one subagent per task, review between tasks — or **superpowers:executing-plans** for batched inline execution.
+Plan complete and saved to `docs/superpowers/plans/2026-06-12-phase-2b-domain-job-income.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-12-rebuild-index.md
+++ b/docs/superpowers/plans/2026-06-12-rebuild-index.md
@@ -31,9 +31,9 @@
 
 | Field | Value |
 |-------|-------|
-| **Current phase** | Phase 2b — plan |
-| **Active plan** | *(to write)* `2026-06-12-phase-2b-domain-social-security.md` |
-| **Next action** | Write Phase 2b plan before coding |
+| **Current phase** | Phase 2c — plan |
+| **Active plan** | *(to write)* `2026-06-12-phase-2c-domain-social-security.md` |
+| **Next action** | Write Phase 2c plan before coding |
 
 When a phase completes: set its plan header to `status: complete`, update this table, and write the next phase plan before coding.
 
@@ -46,8 +46,8 @@ flowchart LR
   P0[Phase 0\nCutover scaffold]
   P1[Phase 1\nCore loop E2E]
   P2a[Phase 2a\nDomain: core types]
-  P2b[Phase 2b\nDomain: SS]
-  P2c[Phase 2c\nDomain: job income]
+  P2b[Phase 2b\nDomain: job income]
+  P2c[Phase 2c\nDomain: SS]
   P2d[Phase 2d\nDomain: pension + taxes]
   P3a[Phase 3a\nSim: data + bootstrap]
   P3b[Phase 3b\nSim: TPAW core]
@@ -60,7 +60,7 @@ flowchart LR
   P2d --> P3a --> P3b --> P3c --> P3d --> P4 --> P5
 ```
 
-Phases 2b–2d may overlap only after 2a lands. Phases 3a–3d must be sequential.
+Phases 2b → 2c → 2d are sequential (job income before SS). Phase 2a must land before 2b. Phases 3a–3d must be sequential.
 
 ---
 
@@ -133,38 +133,38 @@ Phases 2b–2d may overlap only after 2a lands. Phases 3a–3d must be sequentia
 
 ---
 
-### Phase 2b — Domain: Social Security
+### Phase 2b — Domain: Job income
 
-**Plan file:** `2026-06-12-phase-2b-domain-social-security.md` *(to write)*
-
-**Delivers:** Port `social_security.py` with monthly boundaries; auto-generated configurable income streams.
-
-**References:** Legacy `backend/app/models/controllers/social_security.py`, tests in `backend/tests/models/controllers/test_social_security.py`, tpaw for output validation only.
-
-**Entry criteria:** Phase 2a complete.
-
-**Exit criteria:**
-- [ ] Ported tests pass (adapted to monthly)
-- [ ] SS projects to unified timed income streams
-- [ ] `packages/domain/OVERVIEW.md` documents port status
-
----
-
-### Phase 2c — Domain: Job income
-
-**Plan file:** `2026-06-12-phase-2c-domain-job-income.md` *(to write)*
+**Plan file:** [`2026-06-12-phase-2b-domain-job-income.md`](2026-06-12-phase-2b-domain-job-income.md)
 
 **Delivers:** Port job income module; stream ends at configured date; feeds SS earnings and taxes. Planned sabbaticals (income break or % reduction over a defined window) via stream composition (see Phase 2a design §6.1).
 
 **References:** Legacy `job_income.py`, related tests; Phase 2a design §4 (growth re-anchoring), §6.1 (composition).
 
-**Entry criteria:** Phase 2a complete (2b may be in progress).
+**Entry criteria:** Phase 2a complete.
 
 **Exit criteria:**
-- [ ] Job income as unified timed stream
-- [ ] Planned sabbaticals: full break and % reduction, composed from segmented streams with correct growth re-anchoring
+- [x] Job income as unified timed stream
+- [x] Planned sabbaticals: full break and % reduction, composed from segmented streams with correct growth re-anchoring
+- [x] No system-level retirement state
+
+---
+
+### Phase 2c — Domain: Social Security
+
+**Plan file:** `2026-06-12-phase-2c-domain-social-security.md` *(to write)*
+
+**Delivers:** Port `social_security.py` with monthly boundaries; auto-generated configurable income streams. Consumes job-income projections for future earnings.
+
+**References:** Legacy `backend/app/models/controllers/social_security.py`, tests in `backend/tests/models/controllers/test_social_security.py`, tpaw for output validation only.
+
+**Entry criteria:** Phase 2b complete.
+
+**Exit criteria:**
+- [ ] Ported tests pass (adapted to monthly)
+- [ ] SS projects to unified timed income streams
 - [ ] SS earnings integration tested (sabbatical-reduced earnings flow through)
-- [ ] No system-level retirement state
+- [ ] `packages/domain/OVERVIEW.md` documents port status
 
 ---
 
@@ -333,9 +333,10 @@ Phases 2b–2d may overlap only after 2a lands. Phases 3a–3d must be sequentia
 | Phase 0 | `2026-06-12-phase-0-cutover-scaffold.md` | complete |
 | Phase 1 | `2026-06-12-phase-1-core-loop.md` | complete |
 | Phase 2a | `2026-06-12-phase-2a-domain-core.md` | complete |
+| Phase 2b | `2026-06-12-phase-2b-domain-job-income.md` | complete |
 
 ---
 
 ## Next step
 
-Write **Phase 2b plan** before coding.
+Write **Phase 2c plan** before coding.

--- a/docs/superpowers/specs/2026-06-12-phase-2a-domain-core-design.md
+++ b/docs/superpowers/specs/2026-06-12-phase-2a-domain-core-design.md
@@ -162,7 +162,7 @@ quantization for the growth factor so projections are deterministic and testable
 > `monthly_amount` set to the **already-grown** value at that segment's start —
 > `base * (1 + g) ** (segment_start_index / 12)` — so the segments stitch back
 > into one continuous `base * (1 + g) ** (t / 12)` curve. This is a **consumer**
-> (Phase 2c) responsibility; `core` only projects each stream independently.
+> (Phase 2b) responsibility; `core` only projects each stream independently.
 
 ---
 
@@ -246,7 +246,7 @@ The lean `TimedStream` is deliberately a single bounded window with one
 expressed by **composing multiple streams** at the consumer layer, not by adding
 timing variants to the primitive.
 
-The motivating example is **planned sabbaticals** (a future Phase 2c feature):
+The motivating example is **planned sabbaticals** (a future Phase 2b feature):
 an income break, or a percentage reduction, over a defined window.
 
 - **Full break** → two streams: the job stream ending at the sabbatical start,
@@ -360,7 +360,7 @@ Do **not** test pure Pydantic validation or trivial getters.
 - One-time amounts, `every-X-months` recurrence, named-age boundaries
   (`lastWorkingMonth`/`retirement`), `inThePast` timing — add per consumer need.
 - **Planned sabbaticals** (income break / % reduction over a window) — expressed
-  by stream composition (§6.1); the feature itself lands in Phase 2c (job income).
+  by stream composition (§6.1); the feature itself lands in Phase 2b (job income).
 - `id` / `sortIndex` / `colorIndex` and stream ordering/overlap validation — add
   with the editor.
 - Future-dated nominal anchoring (the 3-way mode) — see §6.

--- a/docs/superpowers/specs/2026-06-12-phase-2b-domain-job-income-design.md
+++ b/docs/superpowers/specs/2026-06-12-phase-2b-domain-job-income-design.md
@@ -1,0 +1,300 @@
+# Phase 2b — Domain: Job Income Design
+
+**Date:** 2026-06-15
+**Status:** Approved
+**Parent:** [2026-06-12-life-finances-rebuild-design.md](./2026-06-12-life-finances-rebuild-design.md)
+**Builds on:** [2026-06-12-phase-2a-domain-core-design.md](./2026-06-12-phase-2a-domain-core-design.md)
+**Phase plan:** `docs/superpowers/plans/2026-06-12-phase-2b-domain-job-income.md` *(to write after spec approval)*
+
+---
+
+## 1. Goal & scope
+
+Port legacy `job_income.py` onto the Phase 2a `TimedStream` foundation.
+
+A person can hold **multiple jobs** (concurrent or sequential). Each job grows with
+raises and can have **per-job sabbatical windows** (a full break or a partial
+reduction over a window). Phase 2b delivers:
+
+1. **Plan-config models** (`Job`, `SabbaticalWindow`) persisted on the `Plan`.
+2. A **domain projection** (`project_job_income`) that compiles jobs into
+   month-indexed series for downstream consumers.
+
+Phase 2b is **not** responsible for: system-level retirement state,
+`try_to_optimize`, the Social Security wage-base cap (Phase 2c), tax computation
+(Phase 2d), `build_monthly_cashflows` aggregation (Phase 2d), inflation
+(simulation layer), nominal jobs, or any editor/UI.
+
+---
+
+## 2. Decisions captured from brainstorming
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **Multiple jobs per person**, concurrent or sequential | Real users hold more than one job over time and at once; the projection sums them per person |
+| 2 | **Per-job sabbatical windows** (not per-person) | Keeps the segment math local to one job's growth curve; a "real" full sabbatical is a window on each active job |
+| 3 | Sabbatical severity = **`remaining_fraction` 0..1** (0 = full break, 0.5 = half pay) | One field expresses both full break and partial reduction |
+| 4 | During a sabbatical the **raise clock keeps running** | Person returns at the grown salary; this is exactly the Phase 2a §6.1 re-anchoring rule, so segments stitch into one continuous curve |
+| 5 | **Annual dollars** on the `Job`, compiled to monthly (÷12) | Matches how users enter salary and 401k/HSA limits |
+| 6 | **Smooth monthly-compounded growth**, reusing `project_stream` | No legacy calendar-year step-ups; we are not chasing legacy numeric parity |
+| 7 | Tax-deferred **stored as the user's annual dollar amount**, modeled **internally as a fraction** of base income | Users understand dollar limits; fractional modeling makes deferral scale with raises and sabbatical reductions (legacy effective behavior). Fixed inflation-only-growth dollars considered and **deferred** (not worth the complexity) |
+| 8 | Keep per-job **`social_security_eligible` flag** | Models SS-covered vs non-covered employment; this fact cannot be reconstructed from a summed gross series |
+| 9 | Projection exposes **per-person breakdowns + household totals** | SS (2c) computes PIA per individual; taxes/cashflows (2d) want household aggregates |
+| 10 | `Job` / `SabbaticalWindow` live in **`core`** | `Plan` persists them through the JSON-blob repository, exactly like `TimedStream` |
+| 11 | **Real-only** jobs (`is_nominal=False`); `annual_raise` is a real raise | Nominal jobs deferred (YAGNI) |
+| 12 | **No system-level retirement state** | Per rebuild-index exit criteria; "retired" is just an absence of income, not a flag |
+
+---
+
+## 3. Config models (`core`)
+
+`Job` and `SabbaticalWindow` live in `core` because `Plan` persists them through
+the existing JSON-blob repository (no schema migration — the `plans` column
+already stores `Plan.model_dump_json()`), exactly as `TimedStream` does.
+
+```python
+from decimal import Decimal
+from pydantic import BaseModel, Field
+from core.streams import Boundary
+
+
+class SabbaticalWindow(BaseModel):
+    """A window over which a job's pay is reduced (or fully paused).
+
+    remaining_fraction is the share of pay still earned: 0 => full break,
+    0.5 => half pay, 1 => no reduction. The job's underlying raise clock keeps
+    running across the window, so the person returns at the grown salary.
+    """
+
+    start: Boundary
+    end: Boundary
+    remaining_fraction: Decimal = Field(ge=0, le=1)
+
+
+class Job(BaseModel):
+    """One job held by a person, as a real (today's-dollar) income source.
+
+    Amounts are annual; the domain compiles them to a monthly TimedStream.
+    annual_raise is a REAL raise (growth above inflation). Inflation is never
+    applied here.
+    """
+
+    label: str | None = None
+    annual_income: Decimal = Field(ge=0)
+    annual_tax_deferred: Decimal = Field(default=Decimal(0), ge=0)
+    annual_raise: Decimal = Decimal(0)
+    start: Boundary | None = None          # None => plan start (month_index 0, "now")
+    end: Boundary | None = None            # None => plan horizon end
+    social_security_eligible: bool = True
+    sabbaticals: list[SabbaticalWindow] = Field(default_factory=list)
+```
+
+`PersonHousehold` gains one field:
+
+```python
+class PersonHousehold(BaseModel):
+    birth_month: int = Field(ge=1, le=12)
+    birth_year: int
+    max_age_years: int = Field(default=100, ge=1)
+    jobs: list[Job] = Field(default_factory=list)   # NEW
+```
+
+The default plan leaves `jobs` empty; existing default-plan behavior is unchanged.
+
+### Validation
+- Field-level: `annual_income >= 0`, `annual_tax_deferred >= 0`,
+  `remaining_fraction in [0, 1]`.
+- Model-level on `Job`: `annual_tax_deferred <= annual_income`.
+- **Sabbatical windows** must resolve (via the timeline) to ranges that are
+  inside `[job start, job end]`, ordered, and non-overlapping. Boundary-to-index
+  resolution needs a `Timeline`, so these structural checks live in the
+  **compiler** (§4) and raise a clear domain error, not in Pydantic field
+  validators.
+
+---
+
+## 4. Compilation: `Job` → segmented `TimedStream`s (`domain`)
+
+A job with *N* sabbatical windows compiles into up to *2N+1* `TimedStream`
+segments (full / reduced / full / …). Each segment reuses the Phase 2a
+`project_stream`, so **all growth math lives in one place**.
+
+Re-anchoring (Phase 2a §6.1) makes the segments stitch into one continuous curve
+with the raise clock running underneath the whole job:
+
+```
+base_monthly      = annual_income / 12
+segment_base(s)   = base_monthly
+                    * remaining_fraction(s)
+                    * (1 + annual_raise) ** ((segment_start_index - job_start_index) / 12)
+```
+
+Each segment becomes:
+
+```python
+TimedStream(
+    monthly_amount=segment_base,
+    start=<segment start boundary>,
+    end=<segment end boundary>,
+    annual_growth_rate=annual_raise,
+    is_nominal=False,
+)
+```
+
+`project_stream` then compounds within the segment, yielding a continuous
+`base_monthly * (1 + annual_raise) ** ((t - job_start_index) / 12)` curve, scaled
+by `remaining_fraction` inside windows. Outside `[job start, job end]` the series
+is zero.
+
+**`job_start_index`** is `0` when `Job.start is None`, else
+`timeline.index_of(job.start)`. The growth anchor is the job start, **not** the
+clamped/visible window, so a job that started in the past still grows correctly
+into the visible horizon.
+
+### `core.timeline.month_boundary` helper (new)
+
+To build segment streams from computed month indices while still reusing
+`project_stream` (rather than re-implementing growth), add the inverse of the
+today-offset:
+
+```python
+def month_boundary(self, index: int) -> CalendarMonthBoundary:
+    """The calendar month at `index` months from today (index 0 == this month)."""
+```
+
+The compiler computes integer segment start/end indices, then converts them to
+`CalendarMonthBoundary` for each segment's `TimedStream`. This keeps a single
+growth implementation and a single index↔calendar mapping.
+
+---
+
+## 5. Output: `JobIncomeProjection` (the Phase 2b deliverable)
+
+```python
+def project_job_income(plan: Plan, timeline: Timeline) -> JobIncomeProjection: ...
+```
+
+```python
+class PersonJobIncome(BaseModel):     # all lists length == timeline.horizon_months
+    gross: list[Decimal]              # all of the person's jobs, summed
+    ss_covered_gross: list[Decimal]   # gross from jobs with social_security_eligible=True, else 0
+    tax_deferred: list[Decimal]       # sum over jobs of gross_job * (annual_tax_deferred / annual_income)
+
+
+class JobIncomeProjection(BaseModel):
+    person1: PersonJobIncome
+    person2: PersonJobIncome
+
+    # household totals (element-wise sums), e.g. as computed properties:
+    #   total_gross, total_ss_covered_gross, total_tax_deferred
+```
+
+- **Per-person** because SS (2c) computes PIA per individual.
+- **`ss_covered_gross` is UNCAPPED.** It is "earnings from SS-covered jobs"; the
+  Social Security wage-base / taxable-maximum cap is applied **downstream in
+  Phase 2c**, never here. The field docstring states this so the boundary is
+  unambiguous.
+- **`tax_deferred`** uses the per-job fraction `annual_tax_deferred / annual_income`
+  (guard divide-by-zero when `annual_income == 0` → fraction 0), applied to that
+  job's already-grown, already-sabbatical-scaled monthly gross, then summed. It
+  therefore scales with raises and reductions automatically.
+- **Concurrent jobs** are summed element-wise per person; **sequential jobs**
+  simply occupy disjoint windows.
+- Household totals are element-wise sums of the two persons' series.
+
+---
+
+## 6. File layout (delta from current tree)
+
+```
+packages/core/
+├── core/
+│   ├── job.py            # NEW — Job, SabbaticalWindow
+│   ├── models.py         # + PersonHousehold.jobs
+│   ├── streams.py        # unchanged (Boundary reused)
+│   └── timeline.py       # + Timeline.month_boundary(index)
+└── tests/
+    ├── test_job.py        # NEW — config validation, repository round-trip
+    └── test_timeline.py   # + month_boundary behavior
+
+packages/domain/
+├── domain/
+│   └── job_income/
+│       ├── __init__.py    # project_job_income, JobIncomeProjection, PersonJobIncome
+│       └── compile.py     # Job -> segmented TimedStreams (re-anchoring, window split)
+├── tests/
+│   └── test_job_income.py # NEW
+└── OVERVIEW.md            # job_income status -> in progress / done
+```
+
+---
+
+## 7. Testing (TDD, one behavior per test)
+
+Per repo testing policy: behavior test first, scaffold to a *logical* red, then
+implement. Inject `today: date`. Pull shared values from source; never duplicate
+a literal across arrange and assert.
+
+| Area | Representative behaviors |
+|------|--------------------------|
+| `Job` validation | `annual_tax_deferred > annual_income` rejected; `remaining_fraction` outside `[0,1]` rejected |
+| Repository round-trip | `Plan` with `PersonHousehold.jobs` (incl. sabbaticals + `Decimal`) → SQLite → equal |
+| `Timeline.month_boundary` | `month_boundary(index)` is the inverse of `index_of(CalendarMonthBoundary)` for sample indices |
+| Single job | annual→monthly conversion; flat-then-grown monthly series matches `base*(1+raise)^(t/12)` |
+| Concurrent jobs | two overlapping jobs sum element-wise per person |
+| Sequential jobs | disjoint windows, no overlap, zero between |
+| Full break (`remaining=0`) | window zeroed; **post-break value equals the no-break curve at that month** (re-anchoring proven) |
+| Partial reduction | window scaled by `remaining_fraction`; growth still compounds underneath |
+| `ss_covered_gross` | excludes jobs with `social_security_eligible=False`; **no cap applied** |
+| `tax_deferred` | equals `gross * (annual_tax_deferred/annual_income)`; scales with growth and reductions; `annual_income==0` → 0 |
+| Household totals | equal element-wise per-person sums |
+
+Do **not** test pure Pydantic validation of trivial fields or library behavior.
+
+---
+
+## 8. Error handling
+
+| Situation | Behavior |
+|-----------|----------|
+| Sabbatical window outside `[job start, job end]` | Compiler raises a clear domain `ValueError` |
+| Overlapping / out-of-order sabbatical windows | Compiler raises a clear domain `ValueError` |
+| `annual_tax_deferred > annual_income` | Pydantic `ValidationError` at model construction |
+| `annual_income == 0` | Allowed (zero-income placeholder job); tax-deferred fraction is 0 |
+| Job window entirely in the past / beyond horizon | All-zero contribution (via `project_stream` clamping), no error |
+| Unknown boundary `kind` in stored JSON | Pydantic discriminated-union `ValidationError`, surfaced by repo as today |
+
+---
+
+## 9. Exit criteria (from rebuild index, made concrete)
+
+- [ ] `Job` + `SabbaticalWindow` in `core`, persisted on `PersonHousehold.jobs`, round-trip through SQLite (proven by test)
+- [ ] Job income projects to month-indexed series via `project_job_income`, reusing `project_stream`
+- [ ] Planned sabbaticals: full break and % reduction, composed from segmented streams with correct growth re-anchoring (raise clock continues)
+- [ ] Per-person `gross` / `ss_covered_gross` / `tax_deferred` + household totals
+- [ ] `ss_covered_gross` is uncapped; wage-base cap explicitly deferred to Phase 2c
+- [ ] No system-level retirement state
+- [ ] `Timeline.month_boundary` added and tested as the inverse of the offset
+- [ ] `packages/domain/OVERVIEW.md` documents job-income port status
+- [ ] `make` (lint + test) passes
+
+---
+
+## 10. Deferred (explicitly out of 2b)
+
+- **Nominal jobs** and future-dated nominal anchoring (Phase 2a §6 deferral stands).
+- **Tax-deferred as fixed inflation-only-growth dollars** — the alternative raised
+  in brainstorming; considered, not worth the added complexity now.
+- **The SS wage-base cap** — Phase 2c.
+- **Tax computation** and `build_monthly_cashflows` aggregation — Phase 2d.
+- **`try_to_optimize`**, system-level retirement state — dropped.
+- **Editor sections** for jobs — Phase 4.
+- **Inflation application** — Phase 3a+.
+
+---
+
+## 11. Next step
+
+After spec approval: invoke **writing-plans** to produce
+`docs/superpowers/plans/2026-06-12-phase-2b-domain-job-income.md`, then execute
+via subagent-driven development.

--- a/docs/superpowers/specs/2026-06-12-phase-2b-domain-job-income-design.md
+++ b/docs/superpowers/specs/2026-06-12-phase-2b-domain-job-income-design.md
@@ -226,9 +226,9 @@ class PersonJobIncome(BaseModel):     # all lists length == timeline.horizon_mon
 class JobIncomeProjection(BaseModel):
     person1: PersonJobIncome
     person2: PersonJobIncome
-
-    # household totals (element-wise sums), e.g. as computed properties:
-    #   total_gross, total_ss_covered_gross, total_tax_deferred
+    total_gross: list[Decimal]              # element-wise sum; computed once at projection
+    total_ss_covered_gross: list[Decimal]
+    total_tax_deferred: list[Decimal]
 ```
 
 - **Per-person** because SS (2c) computes PIA per individual.

--- a/docs/superpowers/specs/2026-06-12-phase-2b-domain-job-income-design.md
+++ b/docs/superpowers/specs/2026-06-12-phase-2b-domain-job-income-design.md
@@ -43,6 +43,7 @@ Phase 2b is **not** responsible for: system-level retirement state,
 | 10 | `Job` / `SabbaticalWindow` live in **`core`** | `Plan` persists them through the JSON-blob repository, exactly like `TimedStream` |
 | 11 | **Real-only** jobs (`is_nominal=False`); `annual_raise` is a real raise | Nominal jobs deferred (YAGNI) |
 | 12 | **No system-level retirement state** | Per rebuild-index exit criteria; "retired" is just an absence of income, not a flag |
+| 13 | Sabbatical-window structure validated by a **`Household` Pydantic validator**, not the compiler | Ordering/overlap/containment only need birth dates (not `today`); `Household` is the lowest level with both persons' birth dates and their jobs, so all boundaries resolve. Compiler can then assume valid input |
 
 ---
 
@@ -102,18 +103,59 @@ class PersonHousehold(BaseModel):
 The default plan leaves `jobs` empty; existing default-plan behavior is unchanged.
 
 ### Validation
-- Field-level: `annual_income >= 0`, `annual_tax_deferred >= 0`,
+
+All validation is **Pydantic** (no separate compiler pass). It splits across two
+levels by what context each level has:
+
+- **Field-level:** `annual_income >= 0`, `annual_tax_deferred >= 0`,
   `remaining_fraction in [0, 1]`.
-- Model-level on `Job`: `annual_tax_deferred <= annual_income`.
-- **Sabbatical windows** must resolve (via the timeline) to ranges that are
-  inside `[job start, job end]`, ordered, and non-overlapping. Boundary-to-index
-  resolution needs a `Timeline`, so these structural checks live in the
-  **compiler** (§4) and raise a clear domain error, not in Pydantic field
-  validators.
+- **Model-level on `Job`:** `annual_tax_deferred <= annual_income`.
+- **Model-level on `Household`** (`model_validator(mode="after")`) — sabbatical
+  window structure. This lives on `Household`, **not `Job`**, because resolving a
+  `PersonAgeBoundary` to a comparable point needs the person's birth date, and a
+  `Job` validator cannot see it. `Household` is the lowest level that has **both**
+  persons' birth dates *and* their jobs, so it can resolve every boundary —
+  including cross-person age references — onto an absolute calendar axis.
+
+  For each person's each job, after resolving boundaries to absolute
+  `year*12 + month`:
+  - each window: `start <= end`;
+  - windows are ordered and **non-overlapping** (next window's start month is
+    strictly after the previous window's end month — windows are inclusive
+    month ranges);
+  - each window lies within the job's **explicit** bounds: if `job.start` is set,
+    `window.start >= job.start`; if `job.end` is set, `window.end <= job.end`.
+
+  Violations raise `ValueError` (Pydantic `ValidationError`).
+
+> **Why no `today` is needed.** Ordering / overlap / containment are *relative*
+> comparisons on the absolute calendar axis. A `CalendarMonthBoundary` is already
+> absolute; a `PersonAgeBoundary` becomes absolute from
+> `birth_year/birth_month + age_months`. Only `month_index` math (offset from now)
+> needs `today` — and that is not required for this validation.
+>
+> **Open bounds are not enforced.** `job.start = None` (plan start) and
+> `job.end = None` (horizon) depend on `today` / max-age, so windows are **not**
+> validated against an open side. A window partly/entirely in the past is clamped
+> to zero by `project_stream` (§4) — clamping, not an error.
+
+A small pure resolver backs this:
+
+```python
+# core.timeline (or a small core helper module)
+def boundary_to_year_month(boundary: Boundary, household: Household) -> tuple[int, int]:
+    """Resolve a boundary to an absolute (year, month). Birth-date only; no `today`."""
+```
+
+`Timeline.index_of` is refactored to reuse it (resolve to (year, month), then
+offset by `today`), keeping a single resolution implementation.
 
 ---
 
 ## 4. Compilation: `Job` → segmented `TimedStream`s (`domain`)
+
+The compiler assumes **already-validated** input (window ordering / overlap /
+containment are enforced by the `Household` validator, §3).
 
 A job with *N* sabbatical windows compiles into up to *2N+1* `TimedStream`
 segments (full / reduced / full / …). Each segment reuses the Phase 2a
@@ -210,12 +252,12 @@ class JobIncomeProjection(BaseModel):
 packages/core/
 ├── core/
 │   ├── job.py            # NEW — Job, SabbaticalWindow
-│   ├── models.py         # + PersonHousehold.jobs
+│   ├── models.py         # + PersonHousehold.jobs; + Household sabbatical-window validator
 │   ├── streams.py        # unchanged (Boundary reused)
-│   └── timeline.py       # + Timeline.month_boundary(index)
+│   └── timeline.py       # + boundary_to_year_month(); + Timeline.month_boundary(index); index_of reuses resolver
 └── tests/
-    ├── test_job.py        # NEW — config validation, repository round-trip
-    └── test_timeline.py   # + month_boundary behavior
+    ├── test_job.py        # NEW — Job + Household validation, repository round-trip
+    └── test_timeline.py   # + month_boundary + boundary_to_year_month behavior
 
 packages/domain/
 ├── domain/
@@ -238,8 +280,9 @@ a literal across arrange and assert.
 | Area | Representative behaviors |
 |------|--------------------------|
 | `Job` validation | `annual_tax_deferred > annual_income` rejected; `remaining_fraction` outside `[0,1]` rejected |
+| `Household` window validation | out-of-order / overlapping windows rejected; window outside an **explicit** `[job.start, job.end]` rejected; mixed calendar+age boundaries resolved correctly; cross-person age boundary resolved; window against an **open** (None) bound is accepted |
 | Repository round-trip | `Plan` with `PersonHousehold.jobs` (incl. sabbaticals + `Decimal`) → SQLite → equal |
-| `Timeline.month_boundary` | `month_boundary(index)` is the inverse of `index_of(CalendarMonthBoundary)` for sample indices |
+| `boundary_to_year_month` / `Timeline.month_boundary` | age + calendar boundaries resolve to absolute (year, month) without `today`; `month_boundary(index)` is the inverse of `index_of(CalendarMonthBoundary)` |
 | Single job | annual→monthly conversion; flat-then-grown monthly series matches `base*(1+raise)^(t/12)` |
 | Concurrent jobs | two overlapping jobs sum element-wise per person |
 | Sequential jobs | disjoint windows, no overlap, zero between |
@@ -257,8 +300,9 @@ Do **not** test pure Pydantic validation of trivial fields or library behavior.
 
 | Situation | Behavior |
 |-----------|----------|
-| Sabbatical window outside `[job start, job end]` | Compiler raises a clear domain `ValueError` |
-| Overlapping / out-of-order sabbatical windows | Compiler raises a clear domain `ValueError` |
+| Sabbatical window outside an **explicit** `[job.start, job.end]` | `Household` validator raises `ValueError` (Pydantic `ValidationError`) |
+| Overlapping / out-of-order sabbatical windows | `Household` validator raises `ValueError` (Pydantic `ValidationError`) |
+| Window against an **open** (`None`) job bound | Accepted; past portion clamped to zero by `project_stream` |
 | `annual_tax_deferred > annual_income` | Pydantic `ValidationError` at model construction |
 | `annual_income == 0` | Allowed (zero-income placeholder job); tax-deferred fraction is 0 |
 | Job window entirely in the past / beyond horizon | All-zero contribution (via `project_stream` clamping), no error |
@@ -271,6 +315,7 @@ Do **not** test pure Pydantic validation of trivial fields or library behavior.
 - [ ] `Job` + `SabbaticalWindow` in `core`, persisted on `PersonHousehold.jobs`, round-trip through SQLite (proven by test)
 - [ ] Job income projects to month-indexed series via `project_job_income`, reusing `project_stream`
 - [ ] Planned sabbaticals: full break and % reduction, composed from segmented streams with correct growth re-anchoring (raise clock continues)
+- [ ] Sabbatical-window ordering / overlap / containment validated by a `Household` Pydantic validator (birth-date resolution, no `today`); `boundary_to_year_month` resolver added and reused by `index_of`
 - [ ] Per-person `gross` / `ss_covered_gross` / `tax_deferred` + household totals
 - [ ] `ss_covered_gross` is uncapped; wage-base cap explicitly deferred to Phase 2c
 - [ ] No system-level retirement state

--- a/packages/core/core/job.py
+++ b/packages/core/core/job.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, Field, model_validator
+
+from core.streams import Boundary
+
+
+class SabbaticalWindow(BaseModel):
+    start: Boundary
+    end: Boundary
+    remaining_fraction: Decimal = Field(ge=0, le=1)
+
+
+class Job(BaseModel):
+    label: str | None = None
+    annual_income: Decimal = Field(ge=0)
+    annual_tax_deferred: Decimal = Field(default=Decimal(0), ge=0)
+    annual_raise: Decimal = Decimal(0)
+    start: Boundary | None = None
+    end: Boundary | None = None
+    social_security_eligible: bool = True
+    sabbaticals: list[SabbaticalWindow] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _tax_deferred_within_income(self) -> Job:
+        if self.annual_tax_deferred > self.annual_income:
+            raise ValueError("annual_tax_deferred must not exceed annual_income")
+        return self

--- a/packages/core/core/models.py
+++ b/packages/core/core/models.py
@@ -2,10 +2,34 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from core.job import Job
 from core.streams import TimedStream
+from core.timeline import boundary_to_year_month
+
+
+def _validate_job_windows(job: Job, household: Household) -> None:
+    def absolute(boundary) -> int:
+        year, month = boundary_to_year_month(boundary, household)
+        return year * 12 + month
+
+    low = absolute(job.start) if job.start is not None else None
+    high = absolute(job.end) if job.end is not None else None
+
+    previous_end: int | None = None
+    for window in job.sabbaticals:
+        start = absolute(window.start)
+        end = absolute(window.end)
+        if start > end:
+            raise ValueError("sabbatical window start must not be after its end")
+        if low is not None and start < low:
+            raise ValueError("sabbatical window starts before the job's start")
+        if high is not None and end > high:
+            raise ValueError("sabbatical window ends after the job's end")
+        if previous_end is not None and start <= previous_end:
+            raise ValueError("sabbatical windows must be ordered and non-overlapping")
+        previous_end = end
 
 
 class PersonHousehold(BaseModel):
@@ -18,6 +42,13 @@ class PersonHousehold(BaseModel):
 class Household(BaseModel):
     person1: PersonHousehold
     person2: PersonHousehold
+
+    @model_validator(mode="after")
+    def _validate_sabbatical_windows(self) -> Household:
+        for person in (self.person1, self.person2):
+            for job in person.jobs:
+                _validate_job_windows(job, self)
+        return self
 
 
 class Portfolio(BaseModel):

--- a/packages/core/core/models.py
+++ b/packages/core/core/models.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 from pydantic import BaseModel, Field
 
+from core.job import Job
 from core.streams import TimedStream
 
 
@@ -11,6 +12,7 @@ class PersonHousehold(BaseModel):
     birth_month: int = Field(ge=1, le=12)
     birth_year: int
     max_age_years: int = Field(default=100, ge=1)
+    jobs: list[Job] = Field(default_factory=list)
 
 
 class Household(BaseModel):

--- a/packages/core/core/timeline.py
+++ b/packages/core/core/timeline.py
@@ -62,6 +62,11 @@ class Timeline:
         year, month = boundary_to_year_month(boundary, self.plan.household)
         return self._offset(year, month)
 
+    def month_boundary(self, index: int) -> CalendarMonthBoundary:
+        """The calendar month at `index` months from today (index 0 == this month)."""
+        year, month = add_months(self.today.year, self.today.month, index)
+        return CalendarMonthBoundary(year=year, month=month)
+
 
 _CENTS = Decimal("0.01")
 

--- a/packages/core/core/timeline.py
+++ b/packages/core/core/timeline.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import ROUND_HALF_UP, Decimal
+from typing import TYPE_CHECKING
 
-from core.models import PersonHousehold, Plan
+if TYPE_CHECKING:
+    from core.models import Household, PersonHousehold, Plan
 from core.streams import (
     Boundary,
     CalendarMonthBoundary,
@@ -16,6 +18,16 @@ def add_months(year: int, month: int, months: int) -> tuple[int, int]:
     """Add `months` to a (year, month) pair. `month` is 1-12."""
     total = year * 12 + (month - 1) + months
     return total // 12, total % 12 + 1
+
+
+def boundary_to_year_month(boundary: Boundary, household: Household) -> tuple[int, int]:
+    """Resolve a boundary to an absolute (year, month). Birth-date only; no `today`."""
+    if isinstance(boundary, CalendarMonthBoundary):
+        return boundary.year, boundary.month
+    if isinstance(boundary, PersonAgeBoundary):
+        person = getattr(household, boundary.person)
+        return add_months(person.birth_year, person.birth_month, boundary.age_months)
+    raise TypeError(f"Unknown boundary: {boundary!r}")
 
 
 def person_end_date(person: PersonHousehold) -> date:
@@ -47,15 +59,8 @@ class Timeline:
         return (year - self.today.year) * 12 + (month - self.today.month)
 
     def index_of(self, boundary: Boundary) -> int:
-        if isinstance(boundary, CalendarMonthBoundary):
-            return self._offset(boundary.year, boundary.month)
-        if isinstance(boundary, PersonAgeBoundary):
-            person = getattr(self.plan.household, boundary.person)
-            reached_year, reached_month = add_months(
-                person.birth_year, person.birth_month, boundary.age_months
-            )
-            return self._offset(reached_year, reached_month)
-        raise TypeError(f"Unknown boundary: {boundary!r}")
+        year, month = boundary_to_year_month(boundary, self.plan.household)
+        return self._offset(year, month)
 
 
 _CENTS = Decimal("0.01")

--- a/packages/core/tests/test_job.py
+++ b/packages/core/tests/test_job.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from datetime import date
 from decimal import Decimal
 
 import pytest
-from core.job import Job
+from core.job import Job, SabbaticalWindow
+from core.repository import PlanRepository
+from core.streams import CalendarMonthBoundary
 from pydantic import ValidationError
 
 
@@ -21,3 +24,30 @@ def test_job_allows_tax_deferred_equal_to_income() -> None:
     job = Job(annual_income=income, annual_tax_deferred=income)
 
     assert job.annual_tax_deferred == income
+
+
+def test_plan_with_jobs_round_trips_through_repository(repo: PlanRepository) -> None:
+    plan_id, plan = repo.get_or_create_default()
+    annual_income = Decimal("120000")
+    job = Job(
+        label="Engineer",
+        annual_income=annual_income,
+        annual_tax_deferred=Decimal("23000"),
+        annual_raise=Decimal("0.03"),
+        end=CalendarMonthBoundary(year=date.today().year + 30, month=1),
+        sabbaticals=[
+            SabbaticalWindow(
+                start=CalendarMonthBoundary(year=date.today().year + 5, month=1),
+                end=CalendarMonthBoundary(year=date.today().year + 5, month=12),
+                remaining_fraction=Decimal("0.5"),
+            )
+        ],
+    )
+    plan.household.person1.jobs.append(job)
+
+    repo.save(plan_id, plan)
+    reloaded = repo.get_by_id(plan_id)
+
+    assert reloaded is not None
+    assert reloaded.household.person1.jobs == plan.household.person1.jobs
+    assert reloaded.household.person1.jobs[0].annual_income == annual_income

--- a/packages/core/tests/test_job.py
+++ b/packages/core/tests/test_job.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from core.job import Job
+from pydantic import ValidationError
+
+
+def test_job_rejects_tax_deferred_above_income() -> None:
+    income = Decimal("100000")
+    too_much_deferred = income + Decimal("1")
+
+    with pytest.raises(ValidationError):
+        Job(annual_income=income, annual_tax_deferred=too_much_deferred)
+
+
+def test_job_allows_tax_deferred_equal_to_income() -> None:
+    income = Decimal("100000")
+
+    job = Job(annual_income=income, annual_tax_deferred=income)
+
+    assert job.annual_tax_deferred == income

--- a/packages/core/tests/test_job.py
+++ b/packages/core/tests/test_job.py
@@ -5,9 +5,17 @@ from decimal import Decimal
 
 import pytest
 from core.job import Job, SabbaticalWindow
+from core.models import Household, PersonHousehold
 from core.repository import PlanRepository
-from core.streams import CalendarMonthBoundary
+from core.streams import CalendarMonthBoundary, PersonAgeBoundary
 from pydantic import ValidationError
+
+
+def _household_with_person1_jobs(jobs: list[Job]) -> Household:
+    return Household(
+        person1=PersonHousehold(birth_month=1, birth_year=1980, jobs=jobs),
+        person2=PersonHousehold(birth_month=1, birth_year=1982),
+    )
 
 
 def test_job_rejects_tax_deferred_above_income() -> None:
@@ -51,3 +59,77 @@ def test_plan_with_jobs_round_trips_through_repository(repo: PlanRepository) -> 
     assert reloaded is not None
     assert reloaded.household.person1.jobs == plan.household.person1.jobs
     assert reloaded.household.person1.jobs[0].annual_income == annual_income
+
+
+def test_overlapping_sabbatical_windows_rejected() -> None:
+    job = Job(
+        annual_income=Decimal("100000"),
+        sabbaticals=[
+            SabbaticalWindow(
+                start=CalendarMonthBoundary(year=2030, month=1),
+                end=CalendarMonthBoundary(year=2030, month=6),
+                remaining_fraction=Decimal("0.5"),
+            ),
+            SabbaticalWindow(
+                start=CalendarMonthBoundary(year=2030, month=6),
+                end=CalendarMonthBoundary(year=2030, month=12),
+                remaining_fraction=Decimal("0"),
+            ),
+        ],
+    )
+
+    with pytest.raises(ValidationError):
+        _household_with_person1_jobs([job])
+
+
+def test_window_outside_explicit_job_bounds_rejected() -> None:
+    job_start_year = 2030
+    job = Job(
+        annual_income=Decimal("100000"),
+        start=CalendarMonthBoundary(year=job_start_year, month=1),
+        end=CalendarMonthBoundary(year=job_start_year + 5, month=12),
+        sabbaticals=[
+            SabbaticalWindow(
+                start=CalendarMonthBoundary(year=job_start_year - 1, month=1),
+                end=CalendarMonthBoundary(year=job_start_year - 1, month=6),
+                remaining_fraction=Decimal("0"),
+            )
+        ],
+    )
+
+    with pytest.raises(ValidationError):
+        _household_with_person1_jobs([job])
+
+
+def test_window_against_open_bound_is_accepted() -> None:
+    job = Job(
+        annual_income=Decimal("100000"),
+        sabbaticals=[
+            SabbaticalWindow(
+                start=PersonAgeBoundary(person="person1", age_months=720),
+                end=PersonAgeBoundary(person="person1", age_months=732),
+                remaining_fraction=Decimal("0"),
+            )
+        ],
+    )
+
+    household = _household_with_person1_jobs([job])
+
+    assert household.person1.jobs[0].sabbaticals[0].remaining_fraction == Decimal("0")
+
+
+def test_cross_person_and_mixed_boundary_kinds_resolve() -> None:
+    job = Job(
+        annual_income=Decimal("100000"),
+        sabbaticals=[
+            SabbaticalWindow(
+                start=CalendarMonthBoundary(year=2030, month=1),
+                end=PersonAgeBoundary(person="person2", age_months=720),
+                remaining_fraction=Decimal("0.5"),
+            )
+        ],
+    )
+
+    household = _household_with_person1_jobs([job])
+
+    assert len(household.person1.jobs[0].sabbaticals) == 1

--- a/packages/core/tests/test_timeline.py
+++ b/packages/core/tests/test_timeline.py
@@ -4,7 +4,12 @@ from datetime import date
 
 from core.defaults import default_plan
 from core.streams import CalendarMonthBoundary, PersonAgeBoundary
-from core.timeline import Timeline, horizon_months, person_end_date
+from core.timeline import (
+    Timeline,
+    boundary_to_year_month,
+    horizon_months,
+    person_end_date,
+)
 
 
 def test_index_of_calendar_month_is_offset_from_today() -> None:
@@ -60,3 +65,25 @@ def test_horizon_months_matches_max_age_person_age_boundary() -> None:
     expected = (later.year - today.year) * 12 + (later.month - today.month)
     assert timeline.horizon_months == expected
     assert horizon_months(plan, today=today) == expected
+
+
+def test_boundary_to_year_month_calendar_is_identity() -> None:
+    year, month = 2031, 7
+
+    result = boundary_to_year_month(
+        CalendarMonthBoundary(year=year, month=month), default_plan().household
+    )
+
+    assert result == (year, month)
+
+
+def test_boundary_to_year_month_person_age_uses_birth_plus_age() -> None:
+    household = default_plan().household
+    person = household.person1
+    age_months = 600  # 50 years
+
+    result = boundary_to_year_month(
+        PersonAgeBoundary(person="person1", age_months=age_months), household
+    )
+
+    assert result == (person.birth_year + age_months // 12, person.birth_month)

--- a/packages/core/tests/test_timeline.py
+++ b/packages/core/tests/test_timeline.py
@@ -87,3 +87,13 @@ def test_boundary_to_year_month_person_age_uses_birth_plus_age() -> None:
     )
 
     assert result == (person.birth_year + age_months // 12, person.birth_month)
+
+
+def test_month_boundary_is_inverse_of_index_of() -> None:
+    timeline = Timeline(default_plan(), today=date(2026, 6, 1))
+    index = 19
+
+    boundary = timeline.month_boundary(index)
+
+    assert isinstance(boundary, CalendarMonthBoundary)
+    assert timeline.index_of(boundary) == index

--- a/packages/domain/OVERVIEW.md
+++ b/packages/domain/OVERVIEW.md
@@ -22,8 +22,8 @@ projected with `core.timeline.project_stream`. See the Phase 2a design spec:
 
 | Legacy module | Destination | Phase | Status |
 |---------------|-------------|-------|--------|
-| `social_security.py` | `domain/social_security/` | 2b | not started |
-| `job_income.py` (incl. planned sabbaticals) | `domain/job_income/` | 2c | not started |
+| `job_income.py` (incl. planned sabbaticals) | `domain/job_income/` | 2b | done |
+| `social_security.py` | `domain/social_security/` | 2c | not started |
 | `pension.py` | `domain/pension/` | 2d | not started |
 | `taxes.py` (income-side) | `domain/taxes/` | 2d | not started |
 | `build_monthly_cashflows(plan)` aggregator | `domain/__init__.py` | 2d | not started |

--- a/packages/domain/domain/job_income/__init__.py
+++ b/packages/domain/domain/job_income/__init__.py
@@ -1,1 +1,65 @@
 """Job income: compile jobs into projected monthly cashflow series."""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+
+from core.models import PersonHousehold, Plan
+from core.timeline import Timeline
+from pydantic import BaseModel
+
+from domain.job_income.compile import project_job_gross
+
+_CENTS = Decimal("0.01")
+
+
+def _add(left: list[Decimal], right: list[Decimal]) -> list[Decimal]:
+    return [a + b for a, b in zip(left, right, strict=True)]
+
+
+class PersonJobIncome(BaseModel):
+    gross: list[Decimal]
+    ss_covered_gross: list[Decimal]
+    tax_deferred: list[Decimal]
+
+
+class JobIncomeProjection(BaseModel):
+    person1: PersonJobIncome
+    person2: PersonJobIncome
+    total_gross: list[Decimal]
+    total_ss_covered_gross: list[Decimal]
+    total_tax_deferred: list[Decimal]
+
+
+def _project_person(person: PersonHousehold, timeline: Timeline) -> PersonJobIncome:
+    horizon = timeline.horizon_months
+    gross = [Decimal("0.00")] * horizon
+    ss_covered = [Decimal("0.00")] * horizon
+    tax_deferred = [Decimal("0.00")] * horizon
+    for job in person.jobs:
+        job_gross = project_job_gross(job, timeline)
+        gross = _add(gross, job_gross)
+        if job.social_security_eligible:
+            ss_covered = _add(ss_covered, job_gross)
+        if job.annual_income > 0:
+            fraction = job.annual_tax_deferred / job.annual_income
+            job_deferred = [
+                (value * fraction).quantize(_CENTS, rounding=ROUND_HALF_UP)
+                for value in job_gross
+            ]
+            tax_deferred = _add(tax_deferred, job_deferred)
+    return PersonJobIncome(
+        gross=gross, ss_covered_gross=ss_covered, tax_deferred=tax_deferred
+    )
+
+
+def project_job_income(plan: Plan, timeline: Timeline) -> JobIncomeProjection:
+    person1 = _project_person(plan.household.person1, timeline)
+    person2 = _project_person(plan.household.person2, timeline)
+    return JobIncomeProjection(
+        person1=person1,
+        person2=person2,
+        total_gross=_add(person1.gross, person2.gross),
+        total_ss_covered_gross=_add(person1.ss_covered_gross, person2.ss_covered_gross),
+        total_tax_deferred=_add(person1.tax_deferred, person2.tax_deferred),
+    )

--- a/packages/domain/domain/job_income/__init__.py
+++ b/packages/domain/domain/job_income/__init__.py
@@ -1,0 +1,1 @@
+"""Job income: compile jobs into projected monthly cashflow series."""

--- a/packages/domain/domain/job_income/compile.py
+++ b/packages/domain/domain/job_income/compile.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from core.job import Job
+from core.streams import TimedStream
+from core.timeline import Timeline, project_stream
+
+_MONTHS_PER_YEAR = Decimal(12)
+
+
+def _segments(
+    job: Job, timeline: Timeline, job_start: int, job_end: int
+) -> list[tuple[int, int, Decimal]]:
+    """(start_index, end_index, remaining_fraction) segments covering the job."""
+    segments: list[tuple[int, int, Decimal]] = []
+    cursor = job_start
+    for window in job.sabbaticals:
+        window_start = timeline.index_of(window.start)
+        window_end = timeline.index_of(window.end)
+        if window_start > cursor:
+            segments.append((cursor, window_start - 1, Decimal(1)))
+        segments.append((window_start, window_end, window.remaining_fraction))
+        cursor = window_end + 1
+    if cursor <= job_end:
+        segments.append((cursor, job_end, Decimal(1)))
+    return segments
+
+
+def _segment_stream(
+    base_monthly: Decimal,
+    remaining: Decimal,
+    segment_start: int,
+    job_start: int,
+    growth: Decimal,
+    timeline: Timeline,
+    segment_end: int,
+) -> TimedStream:
+    anchor_exponent = Decimal(segment_start - job_start) / _MONTHS_PER_YEAR
+    segment_base = base_monthly * remaining * (Decimal(1) + growth) ** anchor_exponent
+    return TimedStream(
+        monthly_amount=segment_base,
+        start=timeline.month_boundary(segment_start),
+        end=timeline.month_boundary(segment_end),
+        annual_growth_rate=growth,
+        is_nominal=False,
+    )
+
+
+def project_job_gross(job: Job, timeline: Timeline) -> list[Decimal]:
+    """Project one job to a horizon-length monthly gross series (sabbaticals applied)."""
+    horizon = timeline.horizon_months
+    series = [Decimal("0.00")] * horizon
+    if horizon <= 0:
+        return series
+
+    base_monthly = job.annual_income / _MONTHS_PER_YEAR
+    growth = job.annual_raise
+    job_start = 0 if job.start is None else timeline.index_of(job.start)
+    job_end = horizon - 1 if job.end is None else timeline.index_of(job.end)
+
+    for segment_start, segment_end, remaining in _segments(
+        job, timeline, job_start, job_end
+    ):
+        if segment_start > segment_end:
+            continue
+        stream = _segment_stream(
+            base_monthly,
+            remaining,
+            segment_start,
+            job_start,
+            growth,
+            timeline,
+            segment_end,
+        )
+        segment_series = project_stream(stream, timeline)
+        for i in range(horizon):
+            series[i] += segment_series[i]
+    return series

--- a/packages/domain/tests/test_job_income.py
+++ b/packages/domain/tests/test_job_income.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from core.defaults import default_plan
+from core.job import Job, SabbaticalWindow
+from core.streams import CalendarMonthBoundary, TimedStream
+from core.timeline import Timeline, add_months, project_stream
+from domain.job_income.compile import project_job_gross
+
+
+def _timeline() -> Timeline:
+    return Timeline(default_plan(), today=date(2026, 1, 1))
+
+
+def test_single_job_matches_growth_curve() -> None:
+    timeline = _timeline()
+    annual_income = Decimal("120000")
+    rate = Decimal("0.12")
+    job = Job(annual_income=annual_income, annual_raise=rate)
+
+    gross = project_job_gross(job, timeline)
+
+    reference = project_stream(
+        TimedStream(
+            monthly_amount=annual_income / Decimal(12), annual_growth_rate=rate
+        ),
+        timeline,
+    )
+    assert gross == reference
+
+
+def test_full_break_zeroes_window_and_resumes_on_curve() -> None:
+    timeline = _timeline()
+    annual_income = Decimal("120000")
+    rate = Decimal("0.12")
+    break_start_index = 12
+    break_end_index = 23
+    resume_index = break_end_index + 1
+    start_y, start_m = add_months(
+        timeline.today.year, timeline.today.month, break_start_index
+    )
+    end_y, end_m = add_months(
+        timeline.today.year, timeline.today.month, break_end_index
+    )
+    job = Job(
+        annual_income=annual_income,
+        annual_raise=rate,
+        sabbaticals=[
+            SabbaticalWindow(
+                start=CalendarMonthBoundary(year=start_y, month=start_m),
+                end=CalendarMonthBoundary(year=end_y, month=end_m),
+                remaining_fraction=Decimal("0"),
+            )
+        ],
+    )
+
+    gross = project_job_gross(job, timeline)
+
+    no_break = project_job_gross(
+        Job(annual_income=annual_income, annual_raise=rate), timeline
+    )
+    assert gross[break_start_index] == Decimal("0.00")
+    assert gross[break_end_index] == Decimal("0.00")
+    assert gross[resume_index] == no_break[resume_index]
+
+
+def test_partial_reduction_scales_window() -> None:
+    timeline = _timeline()
+    annual_income = Decimal("120000")
+    remaining = Decimal("0.5")
+    window_index = 6
+    win_y, win_m = add_months(timeline.today.year, timeline.today.month, window_index)
+    job = Job(
+        annual_income=annual_income,
+        sabbaticals=[
+            SabbaticalWindow(
+                start=CalendarMonthBoundary(year=win_y, month=win_m),
+                end=CalendarMonthBoundary(year=win_y, month=win_m),
+                remaining_fraction=remaining,
+            )
+        ],
+    )
+
+    gross = project_job_gross(job, timeline)
+
+    full_monthly = (annual_income / Decimal(12)).quantize(Decimal("0.01"))
+    assert gross[window_index] == (full_monthly * remaining).quantize(Decimal("0.01"))

--- a/packages/domain/tests/test_job_income.py
+++ b/packages/domain/tests/test_job_income.py
@@ -5,8 +5,10 @@ from decimal import Decimal
 
 from core.defaults import default_plan
 from core.job import Job, SabbaticalWindow
+from core.models import Household, PersonHousehold, Plan
 from core.streams import CalendarMonthBoundary, TimedStream
 from core.timeline import Timeline, add_months, project_stream
+from domain.job_income import project_job_income
 from domain.job_income.compile import project_job_gross
 
 
@@ -87,3 +89,102 @@ def test_partial_reduction_scales_window() -> None:
 
     full_monthly = (annual_income / Decimal(12)).quantize(Decimal("0.01"))
     assert gross[window_index] == (full_monthly * remaining).quantize(Decimal("0.01"))
+
+
+def _plan_with_jobs(person1_jobs: list[Job], person2_jobs: list[Job]) -> Plan:
+    base = default_plan()
+    return Plan(
+        name=base.name,
+        household=Household(
+            person1=PersonHousehold(
+                birth_month=base.household.person1.birth_month,
+                birth_year=base.household.person1.birth_year,
+                max_age_years=base.household.person1.max_age_years,
+                jobs=person1_jobs,
+            ),
+            person2=PersonHousehold(
+                birth_month=base.household.person2.birth_month,
+                birth_year=base.household.person2.birth_year,
+                max_age_years=base.household.person2.max_age_years,
+                jobs=person2_jobs,
+            ),
+        ),
+        portfolio=base.portfolio,
+    )
+
+
+def test_concurrent_jobs_sum_per_person() -> None:
+    timeline = _timeline()
+    income_a = Decimal("60000")
+    income_b = Decimal("36000")
+    plan = _plan_with_jobs(
+        [Job(annual_income=income_a), Job(annual_income=income_b)], []
+    )
+
+    projection = project_job_income(plan, timeline)
+
+    expected_month0 = (income_a / Decimal(12) + income_b / Decimal(12)).quantize(
+        Decimal("0.01")
+    )
+    assert projection.person1.gross[0] == expected_month0
+
+
+def test_non_ss_covered_job_excluded_from_ss_series() -> None:
+    timeline = _timeline()
+    covered = Decimal("60000")
+    uncovered = Decimal("48000")
+    plan = _plan_with_jobs(
+        [
+            Job(annual_income=covered, social_security_eligible=True),
+            Job(annual_income=uncovered, social_security_eligible=False),
+        ],
+        [],
+    )
+
+    projection = project_job_income(plan, timeline)
+
+    assert projection.person1.gross[0] == (
+        covered / Decimal(12) + uncovered / Decimal(12)
+    ).quantize(Decimal("0.01"))
+    assert projection.person1.ss_covered_gross[0] == (covered / Decimal(12)).quantize(
+        Decimal("0.01")
+    )
+
+
+def test_tax_deferred_scales_with_income_fraction() -> None:
+    timeline = _timeline()
+    income = Decimal("100000")
+    deferred = Decimal("20000")
+    plan = _plan_with_jobs(
+        [Job(annual_income=income, annual_tax_deferred=deferred)], []
+    )
+
+    projection = project_job_income(plan, timeline)
+
+    fraction = deferred / income
+    expected = ((income / Decimal(12)).quantize(Decimal("0.01")) * fraction).quantize(
+        Decimal("0.01")
+    )
+    assert projection.person1.tax_deferred[0] == expected
+
+
+def test_zero_income_job_has_zero_tax_deferred() -> None:
+    timeline = _timeline()
+    plan = _plan_with_jobs([Job(annual_income=Decimal("0"))], [])
+
+    projection = project_job_income(plan, timeline)
+
+    assert all(value == Decimal("0.00") for value in projection.person1.tax_deferred)
+
+
+def test_household_totals_equal_sum_of_persons() -> None:
+    timeline = _timeline()
+    income1 = Decimal("90000")
+    income2 = Decimal("72000")
+    plan = _plan_with_jobs([Job(annual_income=income1)], [Job(annual_income=income2)])
+
+    projection = project_job_income(plan, timeline)
+
+    assert projection.total_gross[0] == (
+        projection.person1.gross[0] + projection.person2.gross[0]
+    )


### PR DESCRIPTION
## Summary

- Add `Job` and `SabbaticalWindow` config models on `PersonHousehold.jobs` with Pydantic validation (tax-deferred cap, household sabbatical window ordering/overlap/bounds).
- Add `boundary_to_year_month` resolver and `Timeline.month_boundary` for birth-date-only boundary resolution and segment compilation.
- Implement `domain/job_income`: `project_job_gross` (sabbatical segments with growth re-anchoring) and `project_job_income` (per-person + household totals for gross, SS-covered gross, tax-deferred).
- Mark Phase 2b complete in rebuild index; active phase now points at Phase 2c.

## Test plan

- [x] `make` passes locally (51 tests, ruff, pyright)
- [x] Core: job model validation, repository round-trip, sabbatical window validation, timeline boundary resolver
- [x] Domain: single-job growth curve, full/partial sabbaticals, concurrent jobs, SS eligibility split, tax-deferred fraction, household totals


Made with [Cursor](https://cursor.com)