### PR TITLE
feat(domain): Phase 2c Social Security

### DIFF
--- a/docs/superpowers/plans/2026-06-12-phase-2c-domain-social-security.md
+++ b/docs/superpowers/plans/2026-06-12-phase-2c-domain-social-security.md
@@ -1,0 +1,1696 @@
+# Phase 2c — Domain Social Security Implementation Plan
+
+**Status:** Complete
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build deterministic, monthly Social Security domain projections from per-person claim ages, SSA historical FICA earnings, and Phase 2b SS-covered job-income projections.
+
+**Architecture:** Per-person Social Security config lives in `core` because it is persisted on `Plan`; one household-level trust factor lives directly on `Household`. Statutory Social Security tables live in `domain/statutory` as versioned source data, while `domain/social_security` owns XML parsing, earnings indexing/capping, PIA math, monthly claim multipliers, spousal alternatives, and `SocialSecurityProjection`.
+
+**Tech Stack:** Python 3.14, Pydantic v2, `Decimal` money math, stdlib XML parsing, pytest, uv workspace. Spec: `docs/superpowers/specs/2026-06-23-phase-2c-domain-social-security-design.md`.
+
+**Conventions for every task:**
+
+- Follow TDD: write the behavior test, scaffold to a *logical* red (`NotImplementedError`, wrong return, or missing validation), confirm the failure is logical, implement, confirm green.
+- Run commands from the repository root: `/Users/chris/Projects/life-finances-workspace/LifeFInances`.
+- Single test command: `uv run pytest <path>::<test_name> -v`.
+- Package-level test command: `uv run pytest packages/core/tests packages/domain/tests -v`.
+- Full verification command: `make`.
+- Bind expected values to variables and reference those variables in both arrange and assert when a value appears in both.
+- Import constants from production modules in tests instead of copying literals, except where the test intentionally pins a public statutory contract and says so in a comment.
+- Commit after each task. The pre-commit hook runs `make`; do not skip it.
+
+---
+
+## File Structure
+
+`packages/core/`
+
+- `core/social_security.py` *(new)* — `AnnualEarnings`, `PersonSocialSecurityConfig`, and Social Security config constants.
+- `core/models.py` *(modify)* — add `PersonHousehold.social_security` and `Household.social_security_trust_factor`.
+- `core/defaults.py` *(modify)* — default plans inherit the new model defaults.
+- `tests/test_social_security.py` *(new)* — core SS config validation and repository round-trip.
+
+`packages/domain/`
+
+- `domain/statutory/__init__.py` *(new)* — exports statutory Social Security table helpers.
+- `domain/statutory/social_security.py` *(new)* — source tables, source metadata, and stdlib log-linear extrapolation.
+- `domain/social_security/__init__.py` *(new)* — `PersonSocialSecurity`, `SocialSecurityProjection`, `project_social_security()`.
+- `domain/social_security/benefits.py` *(new)* — AIME, PIA, claim-age multiplier.
+- `domain/social_security/earnings.py` *(new)* — SSA XML parser, future-earnings grouping, capping/indexing pipeline.
+- `tests/test_social_security.py` *(new)* — parser, statutory helpers, benefits, projection, and integration tests.
+- `OVERVIEW.md` *(modify)* — Social Security port status.
+
+`docs/superpowers/plans/`
+
+- `2026-06-12-rebuild-index.md` *(modify at phase completion)* — mark Phase 2c complete and point active phase to Phase 2d planning.
+
+---
+
+## Task 1: Core Social Security Config
+
+**Files:**
+
+- Create: `packages/core/core/social_security.py`
+- Modify: `packages/core/core/models.py`
+- Test: `packages/core/tests/test_social_security.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# packages/core/tests/test_social_security.py
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from core.defaults import default_plan
+from core.models import Household, PersonHousehold, Plan
+from core.repository import PlanRepository
+from core.social_security import (
+    AnnualEarnings,
+    FULL_RETIREMENT_AGE_MONTHS,
+    MAX_CLAIM_AGE_MONTHS,
+    MIN_CLAIM_AGE_MONTHS,
+    PersonSocialSecurityConfig,
+)
+
+
+def test_default_plan_has_social_security_defaults() -> None:
+    plan = default_plan()
+
+    assert plan.household.person1.social_security.claim_age_months == (
+        FULL_RETIREMENT_AGE_MONTHS
+    )
+    assert plan.household.person2.social_security.claim_age_months == (
+        FULL_RETIREMENT_AGE_MONTHS
+    )
+    assert plan.household.social_security_trust_factor == Decimal("1")
+
+
+def test_claim_age_must_be_between_62_and_70() -> None:
+    too_early = MIN_CLAIM_AGE_MONTHS - 1
+    too_late = MAX_CLAIM_AGE_MONTHS + 1
+
+    with pytest.raises(ValidationError):
+        PersonSocialSecurityConfig(claim_age_months=too_early)
+
+    with pytest.raises(ValidationError):
+        PersonSocialSecurityConfig(claim_age_months=too_late)
+
+
+def test_household_trust_factor_must_be_between_zero_and_one() -> None:
+    base = default_plan().household
+    too_high = Decimal("1.01")
+
+    with pytest.raises(ValidationError):
+        Household(
+            person1=base.person1,
+            person2=base.person2,
+            social_security_trust_factor=too_high,
+        )
+
+
+def test_social_security_config_round_trips_through_repository(
+    repo: PlanRepository,
+) -> None:
+    plan_id, plan = repo.get_or_create_default()
+    expected_claim_age = MIN_CLAIM_AGE_MONTHS
+    expected_trust = Decimal("0.76")
+    expected_earnings = [
+        AnnualEarnings(year=2023, fica_earnings=Decimal("160200")),
+        AnnualEarnings(year=2024, fica_earnings=Decimal("52700")),
+    ]
+
+    updated_plan = Plan(
+        name=plan.name,
+        household=Household(
+            person1=PersonHousehold(
+                birth_month=plan.household.person1.birth_month,
+                birth_year=plan.household.person1.birth_year,
+                max_age_years=plan.household.person1.max_age_years,
+                jobs=plan.household.person1.jobs,
+                social_security=PersonSocialSecurityConfig(
+                    claim_age_months=expected_claim_age,
+                    earnings_record=expected_earnings,
+                ),
+            ),
+            person2=plan.household.person2,
+            social_security_trust_factor=expected_trust,
+        ),
+        portfolio=plan.portfolio,
+        manual_income_streams=plan.manual_income_streams,
+    )
+
+    repo.save(plan_id, updated_plan)
+    loaded = repo.get_by_id(plan_id)
+
+    assert loaded is not None
+    assert loaded.household.person1.social_security.claim_age_months == (
+        expected_claim_age
+    )
+    assert loaded.household.person1.social_security.earnings_record == (
+        expected_earnings
+    )
+    assert loaded.household.social_security_trust_factor == expected_trust
+```
+
+- [ ] **Step 2: Scaffold to a logical red**
+
+Create `packages/core/core/social_security.py` with structure but no validation bounds so the bounds tests fail logically:
+
+```python
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+MIN_CLAIM_AGE_MONTHS = 62 * 12
+FULL_RETIREMENT_AGE_MONTHS = 67 * 12
+MAX_CLAIM_AGE_MONTHS = 70 * 12
+
+
+class AnnualEarnings(BaseModel):
+    """One SSA historical annual FICA earnings row."""
+
+    year: int
+    fica_earnings: Decimal = Field(ge=0)
+
+
+class PersonSocialSecurityConfig(BaseModel):
+    """Per-person Social Security calculation inputs."""
+
+    claim_age_months: int = FULL_RETIREMENT_AGE_MONTHS
+    earnings_record: list[AnnualEarnings] = Field(default_factory=list)
+```
+
+Modify `packages/core/core/models.py` imports and models:
+
+```python
+from core.social_security import PersonSocialSecurityConfig
+```
+
+```python
+class PersonHousehold(BaseModel):
+    birth_month: int = Field(ge=1, le=12)
+    birth_year: int
+    max_age_years: int = Field(default=100, ge=1)
+    jobs: list[Job] = Field(default_factory=list)
+    social_security: PersonSocialSecurityConfig = Field(
+        default_factory=PersonSocialSecurityConfig
+    )
+```
+
+```python
+class Household(BaseModel):
+    person1: PersonHousehold
+    person2: PersonHousehold
+    social_security_trust_factor: Decimal = Decimal(1)
+```
+
+- [ ] **Step 3: Run tests to verify logical failures**
+
+Run: `uv run pytest packages/core/tests/test_social_security.py -v`
+
+Expected: FAIL with `DID NOT RAISE ValidationError` for the claim-age and trust-factor tests. Import errors mean the scaffold is incomplete and must be fixed before implementation.
+
+- [ ] **Step 4: Implement validation bounds**
+
+Replace `PersonSocialSecurityConfig.claim_age_months` in `packages/core/core/social_security.py`:
+
+```python
+class PersonSocialSecurityConfig(BaseModel):
+    """Per-person Social Security calculation inputs."""
+
+    claim_age_months: int = Field(
+        default=FULL_RETIREMENT_AGE_MONTHS,
+        ge=MIN_CLAIM_AGE_MONTHS,
+        le=MAX_CLAIM_AGE_MONTHS,
+    )
+    earnings_record: list[AnnualEarnings] = Field(default_factory=list)
+```
+
+Replace `Household.social_security_trust_factor` in `packages/core/core/models.py`:
+
+```python
+class Household(BaseModel):
+    person1: PersonHousehold
+    person2: PersonHousehold
+    social_security_trust_factor: Decimal = Field(default=Decimal(1), ge=0, le=1)
+```
+
+Keep the existing `Household._validate_sabbatical_windows()` validator below these fields.
+
+- [ ] **Step 5: Run tests to verify green**
+
+Run: `uv run pytest packages/core/tests/test_social_security.py packages/core/tests/test_repository.py -v`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/core/social_security.py packages/core/core/models.py packages/core/tests/test_social_security.py
+git commit -m "feat(core): add Social Security plan config"
+```
+
+---
+
+## Task 2: Statutory Social Security Tables
+
+**Files:**
+
+- Create: `packages/domain/domain/statutory/__init__.py`
+- Create: `packages/domain/domain/statutory/social_security.py`
+- Test: `packages/domain/tests/test_social_security.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# packages/domain/tests/test_social_security.py
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from domain.statutory.social_security import (
+    AWI_INDEX_BY_YEAR,
+    CURRENT_BEND_POINTS,
+    LAST_REVIEWED_YEAR,
+    PIA_RATES,
+    SS_MAX_EARNINGS_BY_YEAR,
+    STALENESS_GRACE_YEARS,
+    is_statutory_data_stale,
+    log_linear_extrapolate,
+    statutory_value_for_year,
+)
+
+
+def test_statutory_tables_sanity_checks() -> None:
+    pinned_taxable_max = Decimal("176100")
+    # Contract test: 2025 SSA taxable maximum is intentionally pinned as a sanity check.
+    assert statutory_value_for_year(SS_MAX_EARNINGS_BY_YEAR, 2025) == (
+        pinned_taxable_max
+    )
+    assert all(isinstance(value, Decimal) for _, value in AWI_INDEX_BY_YEAR)
+    assert CURRENT_BEND_POINTS[0] < CURRENT_BEND_POINTS[1]
+    assert PIA_RATES[0] > PIA_RATES[1]
+    assert PIA_RATES[1] > PIA_RATES[2]
+
+
+def test_statutory_data_is_fresh_within_grace_window() -> None:
+    last_fresh_year = LAST_REVIEWED_YEAR + STALENESS_GRACE_YEARS - 1
+
+    assert is_statutory_data_stale(last_fresh_year) is False
+
+
+def test_statutory_data_is_stale_past_grace_window() -> None:
+    first_stale_year = LAST_REVIEWED_YEAR + STALENESS_GRACE_YEARS
+
+    assert is_statutory_data_stale(first_stale_year) is True
+
+
+def test_statutory_data_is_not_stale_today() -> None:
+    # Intentional real-calendar reminder: when this fails, verify the SSA tables
+    # against their source URLs, refresh any changed values, and bump
+    # LAST_REVIEWED_YEAR.
+    assert is_statutory_data_stale(date.today().year) is False, (
+        "Social Security statutory data is overdue for review; "
+        "verify against source URLs and bump LAST_REVIEWED_YEAR."
+    )
+
+
+def test_log_linear_extrapolate_extends_two_year_growth() -> None:
+    first_year = 2000
+    second_year = 2001
+    first_value = Decimal("100")
+    second_value = Decimal("121")
+    requested_year = 2002
+    source_rows = [(first_year, first_value), (second_year, second_value)]
+
+    result = log_linear_extrapolate(source_rows, requested_year)
+
+    expected = second_value * (second_value / first_value)
+    assert float(result) == pytest.approx(float(expected), rel=0.0001)
+```
+
+- [ ] **Step 2: Scaffold to a logical red**
+
+Create empty package files and a helper that raises `NotImplementedError`:
+
+```python
+# packages/domain/domain/statutory/__init__.py
+"""Versioned statutory tables used by domain calculations."""
+```
+
+```python
+# packages/domain/domain/statutory/social_security.py
+from __future__ import annotations
+
+from decimal import Decimal
+
+LAST_REVIEWED_YEAR = 2026
+STALENESS_GRACE_YEARS = 2
+
+SS_MAX_EARNINGS_BY_YEAR: tuple[tuple[int, Decimal], ...] = ()
+AWI_INDEX_BY_YEAR: tuple[tuple[int, Decimal], ...] = ()
+CURRENT_BEND_POINTS: tuple[Decimal, Decimal] = (Decimal("0"), Decimal("0"))
+PIA_RATES: tuple[Decimal, Decimal, Decimal] = (
+    Decimal("0"),
+    Decimal("0"),
+    Decimal("0"),
+)
+
+
+def is_statutory_data_stale(current_year: int) -> bool:
+    raise NotImplementedError("staleness check is not implemented yet")
+
+
+def log_linear_extrapolate(
+    rows: tuple[tuple[int, Decimal], ...] | list[tuple[int, Decimal]],
+    year: int,
+) -> Decimal:
+    raise NotImplementedError("log-linear extrapolation is not implemented yet")
+
+
+def statutory_value_for_year(
+    rows: tuple[tuple[int, Decimal], ...],
+    year: int,
+) -> Decimal:
+    raise NotImplementedError("statutory lookup is not implemented yet")
+```
+
+- [ ] **Step 3: Run tests to verify logical failures**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py::test_log_linear_extrapolate_extends_two_year_growth packages/domain/tests/test_social_security.py::test_statutory_data_is_stale_past_grace_window -v`
+
+Expected: FAIL with `NotImplementedError`.
+
+- [ ] **Step 4: Implement tables and helpers**
+
+Replace `packages/domain/domain/statutory/social_security.py`:
+
+```python
+from __future__ import annotations
+
+import math
+from decimal import Decimal
+
+# Update procedure: once a year, verify each value below against its source URL,
+# refresh any that changed, then set LAST_REVIEWED_YEAR to the current year.
+# `is_statutory_data_stale` turns this into a soft CI reminder (see below).
+LAST_REVIEWED_YEAR = 2026
+STALENESS_GRACE_YEARS = 2
+
+# Append-only historical records: each year's row is permanent. Add a new row
+# each year; never edit prior rows.
+SOURCE_NOTES = {
+    "taxable_max": "SSA maximum taxable earnings (append-only history): https://www.ssa.gov/benefits/retirement/planner/maxtax.html",
+    "awi_index": "SSA indexing factors (append-only history): https://www.ssa.gov/cgi-bin/awiFactors.cgi",
+    "current_bend_points": "SSA bend points (single current set, replaced yearly): https://www.ssa.gov/oact/cola/bendpoints.html",
+    "pia_rates": "SSA PIA formula (single current set): https://www.ssa.gov/oact/cola/piaformula.html",
+}
+
+SS_MAX_EARNINGS_BY_YEAR: tuple[tuple[int, Decimal], ...] = (
+    (2002, Decimal("84900")),
+    (2003, Decimal("87000")),
+    (2004, Decimal("87900")),
+    (2005, Decimal("90000")),
+    (2006, Decimal("94200")),
+    (2007, Decimal("97500")),
+    (2008, Decimal("102000")),
+    (2009, Decimal("106800")),
+    (2010, Decimal("106800")),
+    (2011, Decimal("106800")),
+    (2012, Decimal("110100")),
+    (2013, Decimal("113700")),
+    (2014, Decimal("117000")),
+    (2015, Decimal("118500")),
+    (2016, Decimal("118500")),
+    (2017, Decimal("127200")),
+    (2018, Decimal("128400")),
+    (2019, Decimal("132900")),
+    (2020, Decimal("137700")),
+    (2021, Decimal("142800")),
+    (2022, Decimal("147000")),
+    (2023, Decimal("160200")),
+    (2024, Decimal("168600")),
+    (2025, Decimal("176100")),
+    (2026, Decimal("184500")),
+)
+
+AWI_INDEX_BY_YEAR: tuple[tuple[int, Decimal], ...] = (
+    (2003, Decimal("1.9557287")),
+    (2004, Decimal("1.8688502")),
+    (2005, Decimal("1.8028823")),
+    (2006, Decimal("1.7236577")),
+    (2007, Decimal("1.6488308")),
+    (2008, Decimal("1.6117539")),
+    (2009, Decimal("1.6364325")),
+    (2010, Decimal("1.5986484")),
+    (2011, Decimal("1.5500792")),
+    (2012, Decimal("1.5031428")),
+    (2013, Decimal("1.4841731")),
+    (2014, Decimal("1.4332965")),
+    (2015, Decimal("1.3851081")),
+    (2016, Decimal("1.3696311")),
+    (2017, Decimal("1.3239129")),
+    (2018, Decimal("1.2776063")),
+    (2019, Decimal("1.2314568")),
+    (2020, Decimal("1.1976178")),
+    (2021, Decimal("1.0998221")),
+    (2022, Decimal("1.0443086")),
+    (2023, Decimal("1.0000000")),
+    (2024, Decimal("1.0000000")),
+)
+
+# Single current sets, not historical records: replace these in place each year.
+CURRENT_BEND_POINTS: tuple[Decimal, Decimal] = (Decimal("1286"), Decimal("7749"))
+PIA_RATES: tuple[Decimal, Decimal, Decimal] = (
+    Decimal("0.90"),
+    Decimal("0.32"),
+    Decimal("0.15"),
+)
+
+
+def is_statutory_data_stale(current_year: int) -> bool:
+    """Whether statutory data is overdue for its annual review.
+
+    Soft reminder: stale only once `current_year` reaches
+    `LAST_REVIEWED_YEAR + STALENESS_GRACE_YEARS`, so a new calendar year alone
+    does not break CI while values are still close enough (real-dollar bend
+    points barely move year to year).
+    """
+    return current_year - LAST_REVIEWED_YEAR >= STALENESS_GRACE_YEARS
+
+
+def log_linear_extrapolate(
+    rows: tuple[tuple[int, Decimal], ...] | list[tuple[int, Decimal]],
+    year: int,
+) -> Decimal:
+    """Estimate `value(year)` from `(year, value)` rows using log-linear fit."""
+    if not rows:
+        raise ValueError("cannot extrapolate an empty statutory table")
+    for source_year, value in rows:
+        if source_year == year:
+            return value
+    x_values = [float(source_year) for source_year, _ in rows]
+    y_values = [math.log(float(value)) for _, value in rows]
+    x_mean = sum(x_values) / len(x_values)
+    y_mean = sum(y_values) / len(y_values)
+    numerator = sum(
+        (x_value - x_mean) * (y_value - y_mean)
+        for x_value, y_value in zip(x_values, y_values, strict=True)
+    )
+    denominator = sum((x_value - x_mean) ** 2 for x_value in x_values)
+    if denominator == 0:
+        return rows[0][1]
+    slope = numerator / denominator
+    intercept = y_mean - slope * x_mean
+    return Decimal(str(math.exp(intercept + slope * float(year))))
+
+
+def statutory_value_for_year(
+    rows: tuple[tuple[int, Decimal], ...],
+    year: int,
+) -> Decimal:
+    """Return exact statutory value when available, otherwise extrapolate."""
+    return log_linear_extrapolate(rows, year)
+```
+
+- [ ] **Step 5: Run tests to verify green**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py -v`
+
+Expected: PASS for the statutory, staleness, and extrapolation tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/domain/domain/statutory packages/domain/tests/test_social_security.py
+git commit -m "feat(domain): add Social Security statutory tables"
+```
+
+---
+
+## Task 3: SSA Statement XML Parser
+
+**Files:**
+
+- Create: `packages/domain/domain/social_security/earnings.py`
+- Modify: `packages/domain/tests/test_social_security.py`
+
+- [ ] **Step 1: Add parser tests**
+
+Append to `packages/domain/tests/test_social_security.py`:
+
+```python
+from core.social_security import AnnualEarnings
+from domain.social_security.earnings import parse_social_security_statement_xml
+
+
+def test_parse_social_security_statement_xml_extracts_fica_earnings() -> None:
+    xml_text = """<?xml version="1.0" encoding="UTF-8"?>
+<osss:OnlineSocialSecurityStatementData xmlns:osss="http://ssa.gov/osss/schemas/2.0">
+  <osss:EarningsRecord>
+    <osss:Earnings startYear="2023" endYear="2023">
+      <osss:FicaEarnings>160200</osss:FicaEarnings>
+      <osss:MedicareEarnings>219491</osss:MedicareEarnings>
+    </osss:Earnings>
+    <osss:Earnings startYear="2025" endYear="2025">
+      <osss:FicaEarnings>-1</osss:FicaEarnings>
+      <osss:MedicareEarnings>-1</osss:MedicareEarnings>
+    </osss:Earnings>
+  </osss:EarningsRecord>
+</osss:OnlineSocialSecurityStatementData>
+"""
+    expected = [AnnualEarnings(year=2023, fica_earnings=Decimal("160200"))]
+
+    earnings = parse_social_security_statement_xml(xml_text)
+
+    assert earnings == expected
+
+
+def test_parse_social_security_statement_xml_rejects_multi_year_rows() -> None:
+    xml_text = """<?xml version="1.0" encoding="UTF-8"?>
+<osss:OnlineSocialSecurityStatementData xmlns:osss="http://ssa.gov/osss/schemas/2.0">
+  <osss:EarningsRecord>
+    <osss:Earnings startYear="2020" endYear="2021">
+      <osss:FicaEarnings>1000</osss:FicaEarnings>
+    </osss:Earnings>
+  </osss:EarningsRecord>
+</osss:OnlineSocialSecurityStatementData>
+"""
+
+    with pytest.raises(ValueError, match="multi-year"):
+        parse_social_security_statement_xml(xml_text)
+
+
+def test_parse_social_security_statement_xml_rejects_missing_record() -> None:
+    xml_text = """<?xml version="1.0" encoding="UTF-8"?>
+<osss:OnlineSocialSecurityStatementData xmlns:osss="http://ssa.gov/osss/schemas/2.0" />
+"""
+
+    with pytest.raises(ValueError, match="EarningsRecord"):
+        parse_social_security_statement_xml(xml_text)
+```
+
+- [ ] **Step 2: Scaffold parser to a logical red**
+
+Create `packages/domain/domain/social_security/earnings.py`:
+
+```python
+from __future__ import annotations
+
+from core.social_security import AnnualEarnings
+
+
+def parse_social_security_statement_xml(xml_text: str) -> list[AnnualEarnings]:
+    raise NotImplementedError("SSA XML parsing is not implemented yet")
+```
+
+Create `packages/domain/domain/social_security/__init__.py`:
+
+```python
+"""Social Security domain projection."""
+```
+
+- [ ] **Step 3: Run parser test to verify logical failure**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py::test_parse_social_security_statement_xml_extracts_fica_earnings -v`
+
+Expected: FAIL with `NotImplementedError`.
+
+- [ ] **Step 4: Implement parser**
+
+Replace `packages/domain/domain/social_security/earnings.py`:
+
+```python
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from xml.etree import ElementTree
+
+from core.social_security import AnnualEarnings
+
+_NAMESPACE = {"osss": "http://ssa.gov/osss/schemas/2.0"}
+
+
+def _required_text(element: ElementTree.Element, path: str, year: int) -> str:
+    child = element.find(path, _NAMESPACE)
+    if child is None or child.text is None:
+        raise ValueError(f"missing {path} for SSA earnings year {year}")
+    return child.text.strip()
+
+
+def parse_social_security_statement_xml(xml_text: str) -> list[AnnualEarnings]:
+    """Parse SSA statement XML into annual capped FICA earnings."""
+    try:
+        root = ElementTree.fromstring(xml_text)
+    except ElementTree.ParseError as exc:
+        raise ValueError("invalid SSA statement XML") from exc
+
+    record = root.find("osss:EarningsRecord", _NAMESPACE)
+    if record is None:
+        raise ValueError("SSA statement XML is missing EarningsRecord")
+
+    earnings: list[AnnualEarnings] = []
+    for row in record.findall("osss:Earnings", _NAMESPACE):
+        start_year_raw = row.attrib.get("startYear")
+        end_year_raw = row.attrib.get("endYear")
+        if start_year_raw is None or end_year_raw is None:
+            raise ValueError("SSA earnings row is missing startYear or endYear")
+        start_year = int(start_year_raw)
+        end_year = int(end_year_raw)
+        if start_year != end_year:
+            raise ValueError(
+                f"SSA earnings row is multi-year: {start_year}-{end_year}"
+            )
+        fica_text = _required_text(row, "osss:FicaEarnings", start_year)
+        try:
+            fica_earnings = Decimal(fica_text)
+        except InvalidOperation as exc:
+            raise ValueError(
+                f"malformed FicaEarnings for SSA earnings year {start_year}"
+            ) from exc
+        if fica_earnings == Decimal("-1"):
+            continue
+        earnings.append(AnnualEarnings(year=start_year, fica_earnings=fica_earnings))
+    return earnings
+```
+
+- [ ] **Step 5: Run parser against the provided SSA XML demo file**
+
+This is a local smoke check against `social-security-statement (1).xml`. The XML
+file contains personal statement data and must remain untracked; do **not** add
+it to git.
+
+Run:
+
+```bash
+uv run python - <<'PY'
+from decimal import Decimal
+from pathlib import Path
+
+from domain.social_security.earnings import parse_social_security_statement_xml
+
+xml_path = Path("social-security-statement (1).xml")
+earnings = parse_social_security_statement_xml(xml_path.read_text())
+
+assert len(earnings) == 13
+assert earnings[0].year == 2012
+assert earnings[0].fica_earnings == Decimal("12872")
+assert earnings[-1].year == 2024
+assert earnings[-1].fica_earnings == Decimal("52700")
+assert all(row.year != 2025 for row in earnings)
+
+print(f"Parsed {len(earnings)} SSA FICA earnings rows from {xml_path}")
+PY
+```
+
+Expected: PASS and output `Parsed 13 SSA FICA earnings rows from social-security-statement (1).xml`.
+
+- [ ] **Step 6: Run parser tests**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py -v`
+
+Expected: PASS for statutory and parser tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/domain/domain/social_security packages/domain/tests/test_social_security.py
+git commit -m "feat(domain): parse SSA statement earnings"
+```
+
+---
+
+## Task 4: AIME, PIA, and Claim-Age Benefits
+
+**Files:**
+
+- Create: `packages/domain/domain/social_security/benefits.py`
+- Modify: `packages/domain/tests/test_social_security.py`
+
+- [ ] **Step 1: Add benefit-math tests**
+
+Append to `packages/domain/tests/test_social_security.py`:
+
+```python
+from core.social_security import FULL_RETIREMENT_AGE_MONTHS
+from domain.social_security.benefits import (
+    calculate_aime,
+    calculate_pia,
+    claim_age_multiplier,
+)
+
+
+def test_calculate_aime_uses_highest_35_years_with_implicit_zeroes() -> None:
+    earning_years = 10
+    annual_earnings = [Decimal("42000")] * earning_years
+
+    aime = calculate_aime(annual_earnings)
+
+    expected = sum(annual_earnings) / Decimal(35 * 12)
+    assert aime == expected
+
+
+def test_calculate_pia_uses_standard_bend_point_formula() -> None:
+    aime = Decimal("9000")
+
+    pia = calculate_pia(aime)
+
+    first_bend, second_bend = CURRENT_BEND_POINTS
+    rate1, rate2, rate3 = PIA_RATES
+    expected = (
+        first_bend * rate1
+        + (second_bend - first_bend) * rate2
+        + (aime - second_bend) * rate3
+    ).quantize(Decimal("0.01"))
+    assert pia == expected
+
+
+def test_claim_age_multiplier_uses_monthly_early_and_delayed_rules() -> None:
+    fra_multiplier = Decimal("1")
+    earliest_claim_age = 62 * 12
+    delayed_claim_age = 70 * 12
+
+    early = claim_age_multiplier(earliest_claim_age)
+    fra = claim_age_multiplier(FULL_RETIREMENT_AGE_MONTHS)
+    delayed = claim_age_multiplier(delayed_claim_age)
+
+    first_36_months = Decimal(36) * Decimal(5) / Decimal(900)
+    remaining_24_months = Decimal(24) * Decimal(5) / Decimal(1200)
+    expected_early = Decimal("1") - first_36_months - remaining_24_months
+    expected_delayed = Decimal("1") + Decimal(36) * Decimal(2) / Decimal(300)
+    assert early == expected_early
+    assert fra == fra_multiplier
+    assert delayed == expected_delayed
+```
+
+- [ ] **Step 2: Scaffold to a logical red**
+
+Create `packages/domain/domain/social_security/benefits.py`:
+
+```python
+from __future__ import annotations
+
+from decimal import Decimal
+
+
+def calculate_aime(indexed_annual_earnings: list[Decimal]) -> Decimal:
+    raise NotImplementedError("AIME calculation is not implemented yet")
+
+
+def calculate_pia(aime: Decimal) -> Decimal:
+    raise NotImplementedError("PIA calculation is not implemented yet")
+
+
+def claim_age_multiplier(claim_age_months: int) -> Decimal:
+    raise NotImplementedError("claim-age multiplier is not implemented yet")
+```
+
+- [ ] **Step 3: Run benefit test to verify logical failure**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py::test_calculate_aime_uses_highest_35_years_with_implicit_zeroes -v`
+
+Expected: FAIL with `NotImplementedError`.
+
+- [ ] **Step 4: Implement benefits**
+
+Replace `packages/domain/domain/social_security/benefits.py`:
+
+```python
+from __future__ import annotations
+
+from decimal import Decimal
+
+from core.social_security import FULL_RETIREMENT_AGE_MONTHS
+from domain.statutory.social_security import CURRENT_BEND_POINTS, PIA_RATES
+
+_CENTS = Decimal("0.01")
+
+
+def calculate_aime(indexed_annual_earnings: list[Decimal]) -> Decimal:
+    """Average indexed monthly earnings from highest 35 annual earnings years."""
+    top_years = sorted(indexed_annual_earnings, reverse=True)[:35]
+    if len(top_years) < 35:
+        top_years = [*top_years, *([Decimal("0")] * (35 - len(top_years)))]
+    return sum(top_years) / Decimal(35 * 12)
+
+
+def calculate_pia(aime: Decimal) -> Decimal:
+    """Primary Insurance Amount using the standard 90/32/15 formula."""
+    first_bend, second_bend = CURRENT_BEND_POINTS
+    rate1, rate2, rate3 = PIA_RATES
+    first_slice = min(aime, first_bend)
+    second_slice = min(max(aime - first_bend, Decimal("0")), second_bend - first_bend)
+    third_slice = max(aime - second_bend, Decimal("0"))
+    return (
+        first_slice * rate1 + second_slice * rate2 + third_slice * rate3
+    ).quantize(_CENTS)
+
+
+def claim_age_multiplier(claim_age_months: int) -> Decimal:
+    """Monthly early/delayed retirement multiplier relative to FRA 67."""
+    if claim_age_months < FULL_RETIREMENT_AGE_MONTHS:
+        months_early = FULL_RETIREMENT_AGE_MONTHS - claim_age_months
+        first_36 = min(months_early, 36)
+        additional = max(months_early - 36, 0)
+        reduction = (
+            Decimal(first_36) * Decimal(5) / Decimal(900)
+            + Decimal(additional) * Decimal(5) / Decimal(1200)
+        )
+        return Decimal("1") - reduction
+    months_delayed = claim_age_months - FULL_RETIREMENT_AGE_MONTHS
+    return Decimal("1") + Decimal(months_delayed) * Decimal(2) / Decimal(300)
+```
+
+- [ ] **Step 5: Run benefit tests**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py -v`
+
+Expected: PASS for statutory, parser, and benefit tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/domain/domain/social_security/benefits.py packages/domain/tests/test_social_security.py
+git commit -m "feat(domain): calculate Social Security benefits"
+```
+
+---
+
+## Task 5: Real-Aware Earnings Pipeline
+
+**Files:**
+
+- Modify: `packages/domain/domain/social_security/earnings.py`
+- Modify: `packages/domain/tests/test_social_security.py`
+
+- [ ] **Step 1: Add earnings-pipeline tests**
+
+Append to `packages/domain/tests/test_social_security.py`:
+
+```python
+from datetime import date
+
+from core.defaults import default_plan
+from core.timeline import Timeline
+from domain.social_security.earnings import (
+    group_monthly_earnings_by_year,
+    indexed_annual_earnings,
+)
+
+
+def test_group_monthly_earnings_by_year_uses_timeline_calendar_months() -> None:
+    plan = default_plan()
+    timeline = Timeline(plan, today=date(2026, 11, 1))
+    year1_month11 = Decimal("100")
+    year1_month12 = Decimal("200")
+    year2_month1 = Decimal("300")
+    monthly = [year1_month11, year1_month12, year2_month1]
+
+    grouped = group_monthly_earnings_by_year(monthly, timeline)
+
+    assert grouped == {2026: year1_month11 + year1_month12, 2027: year2_month1}
+
+
+def test_indexed_annual_earnings_indexes_history_but_not_future_real_income() -> None:
+    historical_year = 2023
+    historical_earning = Decimal("1000")
+    future_year = 2026
+    historical = [AnnualEarnings(year=historical_year, fica_earnings=historical_earning)]
+    future = {future_year: Decimal("2000")}
+
+    earnings = indexed_annual_earnings(
+        historical_earnings=historical,
+        future_real_earnings_by_year=future,
+        today_year=2026,
+    )
+
+    historical_index = statutory_value_for_year(AWI_INDEX_BY_YEAR, historical_year)
+    expected_history = historical_earning * historical_index
+    assert expected_history in earnings
+    assert future[future_year] in earnings
+```
+
+- [ ] **Step 2: Scaffold to a logical red**
+
+Append stubs to `packages/domain/domain/social_security/earnings.py`:
+
+```python
+from core.timeline import Timeline
+
+
+def group_monthly_earnings_by_year(
+    monthly_earnings: list[Decimal],
+    timeline: Timeline,
+) -> dict[int, Decimal]:
+    raise NotImplementedError("future earnings grouping is not implemented yet")
+
+
+def indexed_annual_earnings(
+    *,
+    historical_earnings: list[AnnualEarnings],
+    future_real_earnings_by_year: dict[int, Decimal],
+    today_year: int,
+) -> list[Decimal]:
+    raise NotImplementedError("earnings indexing is not implemented yet")
+```
+
+- [ ] **Step 3: Run grouping test to verify logical failure**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py::test_group_monthly_earnings_by_year_uses_timeline_calendar_months -v`
+
+Expected: FAIL with `NotImplementedError`.
+
+- [ ] **Step 4: Implement grouping and real-aware indexing**
+
+Add imports to `packages/domain/domain/social_security/earnings.py`:
+
+```python
+from domain.statutory.social_security import (
+    AWI_INDEX_BY_YEAR,
+    SS_MAX_EARNINGS_BY_YEAR,
+    statutory_value_for_year,
+)
+```
+
+Replace the stubs:
+
+```python
+def group_monthly_earnings_by_year(
+    monthly_earnings: list[Decimal],
+    timeline: Timeline,
+) -> dict[int, Decimal]:
+    """Group monthly real earnings by calendar year.
+
+    Index 0 is the current calendar month. Partial first and final years include
+    only months present in the simulation horizon.
+    """
+    grouped: dict[int, Decimal] = {}
+    for month_index, earnings in enumerate(monthly_earnings):
+        boundary = timeline.month_boundary(month_index)
+        grouped[boundary.year] = grouped.get(boundary.year, Decimal("0")) + earnings
+    return grouped
+
+
+def _indexed_taxable_max(year: int) -> Decimal:
+    nominal_max = statutory_value_for_year(SS_MAX_EARNINGS_BY_YEAR, year)
+    index = statutory_value_for_year(AWI_INDEX_BY_YEAR, year)
+    return nominal_max * index
+
+
+def indexed_annual_earnings(
+    *,
+    historical_earnings: list[AnnualEarnings],
+    future_real_earnings_by_year: dict[int, Decimal],
+    today_year: int,
+) -> list[Decimal]:
+    """Return annual earnings in today's-dollar basis for AIME.
+
+    Historical earnings are nominal and indexed. Future job-income projections
+    are already real dollars, so they are capped in the calculation basis but
+    not indexed again.
+    """
+    values: list[Decimal] = []
+    for row in historical_earnings:
+        capped_nominal = min(
+            row.fica_earnings,
+            statutory_value_for_year(SS_MAX_EARNINGS_BY_YEAR, row.year),
+        )
+        index = statutory_value_for_year(AWI_INDEX_BY_YEAR, row.year)
+        values.append(capped_nominal * index)
+    for year, earnings in future_real_earnings_by_year.items():
+        if year < today_year:
+            continue
+        values.append(min(earnings, _indexed_taxable_max(year)))
+    return values
+```
+
+- [ ] **Step 5: Run earnings tests**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py -v`
+
+Expected: PASS for statutory, parser, benefits, and earnings tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/domain/domain/social_security/earnings.py packages/domain/tests/test_social_security.py
+git commit -m "feat(domain): build Social Security earnings pipeline"
+```
+
+---
+
+## Task 6: Social Security Projection and Own Benefits
+
+**Files:**
+
+- Modify: `packages/domain/domain/social_security/__init__.py`
+- Modify: `packages/domain/tests/test_social_security.py`
+
+- [ ] **Step 1: Add projection tests for own benefits and shape**
+
+Append to `packages/domain/tests/test_social_security.py`:
+
+```python
+from core.models import Household, PersonHousehold, Plan, Portfolio
+from core.social_security import PersonSocialSecurityConfig
+from domain.job_income import JobIncomeProjection, PersonJobIncome
+from domain.social_security import project_social_security
+
+
+def _zero_job_income(horizon: int) -> JobIncomeProjection:
+    zeroes = [Decimal("0.00")] * horizon
+    person = PersonJobIncome(gross=zeroes, ss_covered_gross=zeroes, tax_deferred=zeroes)
+    return JobIncomeProjection(
+        person1=person,
+        person2=person,
+        total_gross=zeroes,
+        total_ss_covered_gross=zeroes,
+        total_tax_deferred=zeroes,
+    )
+
+
+def _ss_plan(
+    *,
+    person1_claim_age_months: int = FULL_RETIREMENT_AGE_MONTHS,
+    person2_claim_age_months: int = FULL_RETIREMENT_AGE_MONTHS,
+    trust_factor: Decimal = Decimal("1"),
+) -> Plan:
+    return Plan(
+        name="SS Test Plan",
+        household=Household(
+            person1=PersonHousehold(
+                birth_month=1,
+                birth_year=1960,
+                social_security=PersonSocialSecurityConfig(
+                    claim_age_months=person1_claim_age_months,
+                    earnings_record=[
+                        AnnualEarnings(year=2023, fica_earnings=Decimal("160200"))
+                    ],
+                ),
+            ),
+            person2=PersonHousehold(
+                birth_month=1,
+                birth_year=1962,
+                social_security=PersonSocialSecurityConfig(
+                    claim_age_months=person2_claim_age_months,
+                ),
+            ),
+            social_security_trust_factor=trust_factor,
+        ),
+        portfolio=Portfolio(current_savings_balance=Decimal("0")),
+    )
+
+
+def test_project_social_security_returns_horizon_length_series() -> None:
+    plan = _ss_plan()
+    timeline = Timeline(plan, today=date(2026, 1, 1))
+    job_income = _zero_job_income(timeline.horizon_months)
+
+    projection = project_social_security(plan, timeline, job_income)
+
+    assert len(projection.person1.max_benefit) == timeline.horizon_months
+    assert len(projection.person2.max_benefit) == timeline.horizon_months
+    assert len(projection.total) == timeline.horizon_months
+
+
+def test_project_social_security_starts_own_benefit_at_claim_month() -> None:
+    claim_age = 67 * 12
+    plan = _ss_plan(person1_claim_age_months=claim_age)
+    timeline = Timeline(plan, today=date(2026, 1, 1))
+    job_income = _zero_job_income(timeline.horizon_months)
+    claim_index = timeline.index_of(
+        PersonAgeBoundary(person="person1", age_months=claim_age)
+    )
+
+    projection = project_social_security(plan, timeline, job_income)
+
+    assert projection.person1.own_benefit[claim_index - 1] == Decimal("0.00")
+    assert projection.person1.own_benefit[claim_index] > Decimal("0.00")
+```
+
+Add import near existing stream imports:
+
+```python
+from core.streams import PersonAgeBoundary, PersonId
+```
+
+- [ ] **Step 2: Scaffold projection to a logical red**
+
+Replace `packages/domain/domain/social_security/__init__.py`:
+
+```python
+from __future__ import annotations
+
+from decimal import Decimal
+
+from core.models import Plan
+from core.timeline import Timeline
+from domain.job_income import JobIncomeProjection
+from pydantic import BaseModel, computed_field
+
+
+class PersonSocialSecurity(BaseModel):
+    own_benefit: list[Decimal]
+    spousal_alternative: list[Decimal]
+    max_benefit: list[Decimal]
+
+    @computed_field
+    @property
+    def spousal_top_up(self) -> list[Decimal]:
+        return [
+            benefit - own
+            for own, benefit in zip(self.own_benefit, self.max_benefit, strict=True)
+        ]
+
+
+class SocialSecurityProjection(BaseModel):
+    person1: PersonSocialSecurity
+    person2: PersonSocialSecurity
+    total: list[Decimal]
+
+
+def project_social_security(
+    plan: Plan,
+    timeline: Timeline,
+    job_income: JobIncomeProjection,
+) -> SocialSecurityProjection:
+    raise NotImplementedError("Social Security projection is not implemented yet")
+```
+
+- [ ] **Step 3: Run projection test to verify logical failure**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py::test_project_social_security_returns_horizon_length_series -v`
+
+Expected: FAIL with `NotImplementedError`.
+
+- [ ] **Step 4: Implement own-benefit projection with zero spousal alternatives**
+
+Replace `packages/domain/domain/social_security/__init__.py`:
+
+```python
+from __future__ import annotations
+
+from decimal import Decimal
+
+from core.models import PersonHousehold, Plan
+from core.streams import PersonAgeBoundary
+from core.timeline import Timeline
+from domain.job_income import JobIncomeProjection
+from domain.social_security.benefits import (
+    calculate_aime,
+    calculate_pia,
+    claim_age_multiplier,
+)
+from domain.social_security.earnings import (
+    group_monthly_earnings_by_year,
+    indexed_annual_earnings,
+)
+from pydantic import BaseModel, computed_field
+
+_CENTS = Decimal("0.01")
+
+
+class PersonSocialSecurity(BaseModel):
+    """Projected Social Security for one person."""
+
+    own_benefit: list[Decimal]
+    spousal_alternative: list[Decimal]
+    max_benefit: list[Decimal]
+
+    @computed_field
+    @property
+    def spousal_top_up(self) -> list[Decimal]:
+        return [
+            benefit - own
+            for own, benefit in zip(self.own_benefit, self.max_benefit, strict=True)
+        ]
+
+
+class SocialSecurityProjection(BaseModel):
+    person1: PersonSocialSecurity
+    person2: PersonSocialSecurity
+    total: list[Decimal]
+
+
+class _PersonInputs(BaseModel):
+    pia: Decimal
+    effective_pia: Decimal
+    claim_multiplier: Decimal
+    claim_start_index: int
+
+
+def _person_inputs(
+    *,
+    person: PersonHousehold,
+    person_id: PersonId,
+    timeline: Timeline,
+    future_ss_covered: list[Decimal],
+    trust_factor: Decimal,
+) -> _PersonInputs:
+    future_by_year = group_monthly_earnings_by_year(future_ss_covered, timeline)
+    earnings = indexed_annual_earnings(
+        historical_earnings=person.social_security.earnings_record,
+        future_real_earnings_by_year=future_by_year,
+        today_year=timeline.today.year,
+    )
+    pia = calculate_pia(calculate_aime(earnings)) if earnings else Decimal("0.00")
+    effective_pia = (pia * trust_factor).quantize(_CENTS)
+    claim_multiplier = claim_age_multiplier(person.social_security.claim_age_months)
+    claim_start_index = timeline.index_of(
+        PersonAgeBoundary(
+            person=person_id, age_months=person.social_security.claim_age_months
+        )
+    )
+    return _PersonInputs(
+        pia=pia,
+        effective_pia=effective_pia,
+        claim_multiplier=claim_multiplier,
+        claim_start_index=claim_start_index,
+    )
+
+
+def _own_series(inputs: _PersonInputs, horizon: int) -> list[Decimal]:
+    series = [Decimal("0.00")] * horizon
+    monthly = (inputs.effective_pia * inputs.claim_multiplier).quantize(_CENTS)
+    low = max(inputs.claim_start_index, 0)
+    for month_index in range(low, horizon):
+        series[month_index] = monthly
+    return series
+
+
+def _person_projection(
+    own_benefit: list[Decimal],
+    spousal_alternative: list[Decimal],
+) -> PersonSocialSecurity:
+    max_benefit = [
+        max(own, spousal)
+        for own, spousal in zip(own_benefit, spousal_alternative, strict=True)
+    ]
+    return PersonSocialSecurity(
+        own_benefit=own_benefit,
+        spousal_alternative=spousal_alternative,
+        max_benefit=max_benefit,
+    )
+
+
+def project_social_security(
+    plan: Plan,
+    timeline: Timeline,
+    job_income: JobIncomeProjection,
+) -> SocialSecurityProjection:
+    horizon = timeline.horizon_months
+    trust_factor = plan.household.social_security_trust_factor
+    person1_inputs = _person_inputs(
+        person=plan.household.person1,
+        person_id="person1",
+        timeline=timeline,
+        future_ss_covered=job_income.person1.ss_covered_gross,
+        trust_factor=trust_factor,
+    )
+    person2_inputs = _person_inputs(
+        person=plan.household.person2,
+        person_id="person2",
+        timeline=timeline,
+        future_ss_covered=job_income.person2.ss_covered_gross,
+        trust_factor=trust_factor,
+    )
+    person1 = _person_projection(_own_series(person1_inputs, horizon), [Decimal("0.00")] * horizon)
+    person2 = _person_projection(_own_series(person2_inputs, horizon), [Decimal("0.00")] * horizon)
+    return SocialSecurityProjection(
+        person1=person1,
+        person2=person2,
+        total=[
+            a + b
+            for a, b in zip(person1.max_benefit, person2.max_benefit, strict=True)
+        ],
+    )
+```
+
+- [ ] **Step 5: Run projection tests**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py -v`
+
+Expected: PASS for all current domain Social Security tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/domain/domain/social_security/__init__.py packages/domain/tests/test_social_security.py
+git commit -m "feat(domain): project Social Security own benefits"
+```
+
+---
+
+## Task 7: Spousal Alternatives and Computed Top-Up
+
+**Files:**
+
+- Modify: `packages/domain/domain/social_security/__init__.py`
+- Modify: `packages/domain/tests/test_social_security.py`
+
+- [ ] **Step 1: Add spousal tests**
+
+Append to `packages/domain/tests/test_social_security.py`:
+
+```python
+def test_spousal_alternative_starts_after_both_people_claim() -> None:
+    person1_claim = 67 * 12
+    person2_claim = 70 * 12
+    plan = _ss_plan(
+        person1_claim_age_months=person1_claim,
+        person2_claim_age_months=person2_claim,
+    )
+    plan.household.person2.social_security.earnings_record = [
+        AnnualEarnings(year=2023, fica_earnings=Decimal("160200"))
+    ]
+    timeline = Timeline(plan, today=date(2026, 1, 1))
+    job_income = _zero_job_income(timeline.horizon_months)
+    person1_claim_index = timeline.index_of(
+        PersonAgeBoundary(person="person1", age_months=person1_claim)
+    )
+    person2_claim_index = timeline.index_of(
+        PersonAgeBoundary(person="person2", age_months=person2_claim)
+    )
+
+    projection = project_social_security(plan, timeline, job_income)
+
+    assert projection.person1.spousal_alternative[person1_claim_index] == (
+        Decimal("0.00")
+    )
+    assert projection.person1.spousal_alternative[person2_claim_index] > (
+        Decimal("0.00")
+    )
+
+
+def test_spousal_top_up_is_max_benefit_minus_own_benefit() -> None:
+    plan = _ss_plan()
+    plan.household.person2.social_security.earnings_record = [
+        AnnualEarnings(year=2023, fica_earnings=Decimal("160200"))
+    ]
+    timeline = Timeline(plan, today=date(2026, 1, 1))
+    job_income = _zero_job_income(timeline.horizon_months)
+
+    projection = project_social_security(plan, timeline, job_income)
+
+    for own, max_benefit, top_up in zip(
+        projection.person1.own_benefit,
+        projection.person1.max_benefit,
+        projection.person1.spousal_top_up,
+        strict=True,
+    ):
+        assert top_up == max_benefit - own
+```
+
+- [ ] **Step 2: Run spousal test to verify logical failure**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py::test_spousal_alternative_starts_after_both_people_claim -v`
+
+Expected: FAIL because `spousal_alternative` stays zero after both claim.
+
+- [ ] **Step 3: Implement spousal alternative series**
+
+Add helper to `packages/domain/domain/social_security/__init__.py` below `_own_series`:
+
+```python
+def _spousal_series(
+    *,
+    receiver_inputs: _PersonInputs,
+    spouse_inputs: _PersonInputs,
+    horizon: int,
+) -> list[Decimal]:
+    SPOUSAL_RATIO = Decimal("0.5")
+    series = _zeroes(horizon)
+    start_index = max(receiver_inputs.claim_start_index, spouse_inputs.claim_start_index)
+    monthly = (
+        spouse_inputs.effective_pia
+        * SPOUSAL_RATIO
+        * receiver_inputs.claim_multiplier
+    ).quantize(_CENTS)
+    low = max(start_index, 0)
+    for month_index in range(low, horizon):
+        series[month_index] = monthly
+    return series
+```
+
+Replace the projection creation in `project_social_security()`:
+
+```python
+    person1_own = _own_series(person1_inputs, horizon)
+    person2_own = _own_series(person2_inputs, horizon)
+    person1_spousal = _spousal_series(
+        receiver_inputs=person1_inputs,
+        spouse_inputs=person2_inputs,
+        horizon=horizon,
+    )
+    person2_spousal = _spousal_series(
+        receiver_inputs=person2_inputs,
+        spouse_inputs=person1_inputs,
+        horizon=horizon,
+    )
+    person1 = _person_projection(person1_own, person1_spousal)
+    person2 = _person_projection(person2_own, person2_spousal)
+```
+
+- [ ] **Step 4: Run spousal tests**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py::test_spousal_alternative_starts_after_both_people_claim packages/domain/tests/test_social_security.py::test_spousal_top_up_is_max_benefit_minus_own_benefit -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full domain SS tests**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py -v`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/domain/domain/social_security/__init__.py packages/domain/tests/test_social_security.py
+git commit -m "feat(domain): add Social Security spousal alternatives"
+```
+
+---
+
+## Task 8: Job-Income Integration and Trust Factor Behavior
+
+**Files:**
+
+- Modify: `packages/domain/tests/test_social_security.py`
+- No production file changes expected if Tasks 5-7 are correct.
+
+- [ ] **Step 1: Add integration tests**
+
+Append to `packages/domain/tests/test_social_security.py`:
+
+```python
+from core.job import Job, SabbaticalWindow
+from core.streams import CalendarMonthBoundary
+from domain.job_income import project_job_income
+
+
+def test_sabbatical_reduced_ss_covered_income_flows_into_projection() -> None:
+    annual_income = Decimal("120000")
+    claim_age_months=67 * 12
+    break_start = CalendarMonthBoundary(year=2026, month=1)
+    break_end = CalendarMonthBoundary(year=2026, month=12)
+    person_with_break = PersonHousehold(
+        birth_month=1,
+        birth_year=1990,
+        social_security=PersonSocialSecurityConfig(claim_age_months=claim_age_months),
+        jobs=[
+            Job(
+                annual_income=annual_income,
+                social_security_eligible=True,
+                sabbaticals=[
+                    SabbaticalWindow(
+                        start=break_start,
+                        end=break_end,
+                        remaining_fraction=Decimal("0"),
+                    )
+                ],
+            )
+        ],
+    )
+    person_without_break = PersonHousehold(
+        birth_month=1,
+        birth_year=1990,
+        social_security=PersonSocialSecurityConfig(claim_age_months=claim_age_months),
+        jobs=[Job(annual_income=annual_income, social_security_eligible=True)],
+    )
+    base = default_plan()
+    plan_with_break = Plan(
+        name="SS Sabbatical",
+        household=Household(person1=person_with_break, person2=base.household.person2),
+        portfolio=base.portfolio,
+    )
+    plan_without_break = Plan(
+        name="SS No Sabbatical",
+        household=Household(
+            person1=person_without_break, person2=base.household.person2
+        ),
+        portfolio=base.portfolio,
+    )
+    timeline_with_break = Timeline(plan_with_break, today=date(2026, 1, 1))
+    timeline_without_break = Timeline(plan_without_break, today=date(2026, 1, 1))
+
+    projection_with_break = project_social_security(
+        plan_with_break,
+        timeline_with_break,
+        project_job_income(plan_with_break, timeline_with_break),
+    )
+    projection_without_break = project_social_security(
+        plan_without_break,
+        timeline_without_break,
+        project_job_income(plan_without_break, timeline_without_break),
+    )
+
+    claim_index = timeline_with_break.index_of(
+        PersonAgeBoundary(person="person1", age_months=claim_age_months)
+    )
+    assert projection_with_break.person1.own_benefit[claim_index] < (
+        projection_without_break.person1.own_benefit[claim_index]
+    )
+
+
+def test_household_trust_factor_scales_projected_benefits() -> None:
+    full_trust = Decimal("1")
+    reduced_trust = Decimal("0.75")
+    full_plan = _ss_plan(trust_factor=full_trust)
+    reduced_plan = _ss_plan(trust_factor=reduced_trust)
+    full_timeline = Timeline(full_plan, today=date(2026, 1, 1))
+    reduced_timeline = Timeline(reduced_plan, today=date(2026, 1, 1))
+    full_projection = project_social_security(
+        full_plan, full_timeline, _zero_job_income(full_timeline.horizon_months)
+    )
+    reduced_projection = project_social_security(
+        reduced_plan,
+        reduced_timeline,
+        _zero_job_income(reduced_timeline.horizon_months),
+    )
+    claim_index = full_timeline.index_of(
+        PersonAgeBoundary(person="person1", age_months=67 * 12)
+    )
+
+    assert reduced_projection.person1.max_benefit[claim_index] == (
+        full_projection.person1.max_benefit[claim_index] * reduced_trust
+    ).quantize(Decimal("0.01"))
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `uv run pytest packages/domain/tests/test_social_security.py::test_sabbatical_reduced_ss_covered_income_flows_into_projection packages/domain/tests/test_social_security.py::test_household_trust_factor_scales_projected_benefits -v`
+
+Expected: PASS. If either test fails, inspect whether Task 5 is excluding future earnings before `today_year`, whether Task 6 uses job-income `ss_covered_gross`, and whether Task 6 applies trust to `effective_pia`.
+
+- [ ] **Step 3: Run all Social Security tests**
+
+Run: `uv run pytest packages/core/tests/test_social_security.py packages/domain/tests/test_social_security.py -v`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/domain/tests/test_social_security.py
+git commit -m "test(domain): cover Social Security job-income integration"
+```
+
+---
+
+## Task 9: Documentation, Index, and Final Verification
+
+**Files:**
+
+- Modify: `packages/domain/OVERVIEW.md`
+- Modify: `docs/superpowers/plans/2026-06-12-rebuild-index.md`
+- Modify: `docs/superpowers/plans/2026-06-12-phase-2c-domain-social-security.md`
+
+- [ ] **Step 1: Update domain overview**
+
+In `packages/domain/OVERVIEW.md`, change the Social Security row:
+
+```markdown
+| `social_security.py` | `domain/social_security/` | 2c | done |
+```
+
+- [ ] **Step 2: Update the rebuild index after implementation completes**
+
+In `docs/superpowers/plans/2026-06-12-rebuild-index.md`, update the active phase table:
+
+```markdown
+| **Current phase** | Phase 2d — plan |
+| **Active plan** | *(to write)* `2026-06-12-phase-2d-domain-pension-taxes.md` |
+| **Next action** | Write Phase 2d plan before coding |
+```
+
+In the Phase 2c exit criteria, change each checkbox to `[x]`.
+
+Add Phase 2c to the completed plans table:
+
+```markdown
+| Phase 2c | `2026-06-12-phase-2c-domain-social-security.md` | complete |
+```
+
+- [ ] **Step 3: Mark this plan complete**
+
+At the top of this file, add the status line after the title:
+
+```markdown
+**Status:** Complete
+```
+
+- [ ] **Step 4: Run full verification**
+
+Run: `make`
+
+Expected: PASS for lint, type checking, and tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/domain/OVERVIEW.md docs/superpowers/plans/2026-06-12-rebuild-index.md docs/superpowers/plans/2026-06-12-phase-2c-domain-social-security.md
+git commit -m "docs(domain): complete Phase 2c Social Security"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+
+- Config models: Task 1.
+- SSA XML parser: Task 3.
+- Statutory tables under `domain/statutory`: Task 2.
+- Real-aware earnings pipeline: Task 5.
+- AIME/PIA standard formula and no WEP path: Task 4.
+- Monthly claim-age formula: Task 4.
+- Household-level trust factor applied to effective PIA: Tasks 1, 6, and 8.
+- Spousal alternatives and computed `spousal_top_up`: Task 7.
+- Projection consumes Phase 2b `JobIncomeProjection`: Tasks 6 and 8.
+- Sabbatical-reduced SS-covered earnings flow through: Task 8.
+- `packages/domain/OVERVIEW.md` and rebuild index updates: Task 9.
+- Final `make`: Task 9.
+
+**Type consistency:**
+
+- Core config names: `AnnualEarnings`, `PersonSocialSecurityConfig`.
+- Household trust field: `Household.social_security_trust_factor`.
+- Domain output names: `PersonSocialSecurity`, `SocialSecurityProjection`.
+- Public parser: `parse_social_security_statement_xml(xml_text: str) -> list[AnnualEarnings]`.
+- Public projection: `project_social_security(plan: Plan, timeline: Timeline, job_income: JobIncomeProjection) -> SocialSecurityProjection`.
+
+**Implementation order:**
+
+Tasks are ordered so every imported symbol is scaffolded before tests rely on implemented behavior. Each task leaves the repository in a committable state with focused tests.

--- a/docs/superpowers/plans/2026-06-12-rebuild-index.md
+++ b/docs/superpowers/plans/2026-06-12-rebuild-index.md
@@ -31,9 +31,9 @@
 
 | Field | Value |
 |-------|-------|
-| **Current phase** | Phase 2c — plan |
-| **Active plan** | *(to write)* `2026-06-12-phase-2c-domain-social-security.md` |
-| **Next action** | Write Phase 2c plan before coding |
+| **Current phase** | Phase 2d — plan |
+| **Active plan** | *(to write)* `2026-06-12-phase-2d-domain-pension-taxes.md` |
+| **Next action** | Write Phase 2d plan before coding |
 
 When a phase completes: set its plan header to `status: complete`, update this table, and write the next phase plan before coding.
 
@@ -152,7 +152,7 @@ Phases 2b → 2c → 2d are sequential (job income before SS). Phase 2a must lan
 
 ### Phase 2c — Domain: Social Security
 
-**Plan file:** `2026-06-12-phase-2c-domain-social-security.md` *(to write)*
+**Plan file:** [`2026-06-12-phase-2c-domain-social-security.md`](2026-06-12-phase-2c-domain-social-security.md)
 
 **Delivers:** Port `social_security.py` with monthly boundaries; auto-generated configurable income streams. Consumes job-income projections for future earnings.
 
@@ -161,10 +161,10 @@ Phases 2b → 2c → 2d are sequential (job income before SS). Phase 2a must lan
 **Entry criteria:** Phase 2b complete.
 
 **Exit criteria:**
-- [ ] Ported tests pass (adapted to monthly)
-- [ ] SS projects to unified timed income streams
-- [ ] SS earnings integration tested (sabbatical-reduced earnings flow through)
-- [ ] `packages/domain/OVERVIEW.md` documents port status
+- [x] Ported tests pass (adapted to monthly)
+- [x] SS projects to unified timed income streams
+- [x] SS earnings integration tested (sabbatical-reduced earnings flow through)
+- [x] `packages/domain/OVERVIEW.md` documents port status
 
 ---
 
@@ -334,9 +334,10 @@ Phases 2b → 2c → 2d are sequential (job income before SS). Phase 2a must lan
 | Phase 1 | `2026-06-12-phase-1-core-loop.md` | complete |
 | Phase 2a | `2026-06-12-phase-2a-domain-core.md` | complete |
 | Phase 2b | `2026-06-12-phase-2b-domain-job-income.md` | complete |
+| Phase 2c | `2026-06-12-phase-2c-domain-social-security.md` | complete |
 
 ---
 
 ## Next step
 
-Write **Phase 2c plan** before coding.
+Write **Phase 2d plan** before coding.

--- a/docs/superpowers/specs/2026-06-23-phase-2c-domain-social-security-design.md
+++ b/docs/superpowers/specs/2026-06-23-phase-2c-domain-social-security-design.md
@@ -1,0 +1,400 @@
+# Phase 2c — Domain: Social Security Design
+
+**Date:** 2026-06-23
+**Status:** Approved
+**Parent:** [2026-06-12-life-finances-rebuild-design.md](./2026-06-12-life-finances-rebuild-design.md)
+**Builds on:** [2026-06-12-phase-2b-domain-job-income-design.md](./2026-06-12-phase-2b-domain-job-income-design.md)
+**Phase plan:** `docs/superpowers/plans/2026-06-12-phase-2c-domain-social-security.md` *(to write after spec approval)*
+
+---
+
+## 1. Goal & scope
+
+Port legacy `social_security.py` onto the Phase 2a/2b monthly domain foundation.
+
+Phase 2c delivers deterministic Social Security projections from a per-person
+claim age, historical SSA earnings records, and Phase 2b projected SS-covered
+job income. The output is a month-indexed `SocialSecurityProjection`, mirroring
+`JobIncomeProjection`, so Phase 2d can consume SS alongside other income sources.
+
+Phase 2c includes:
+
+1. **Plan-config models** for Social Security claim age, trust factor, and
+   historical annual FICA earnings.
+2. A **pure SSA statement XML parser** that extracts historical capped FICA
+   earnings from SSA's exportable XML.
+3. A **real-aware benefit calculation**: historical nominal earnings are indexed
+   to today's dollars, while future job-income projections are already real and
+   are not indexed again.
+4. A **monthly claim-age formula** relative to Full Retirement Age 67.
+5. **Spousal alternatives** and household totals in the projected output.
+
+Phase 2c does **not** include upload UI or persistence wiring for SSA XML; those
+belong in Phase 4 with the rest of the editor/import UI.
+
+Dropped from the legacy model:
+
+- **Net-worth claiming** — it is simulation-state-dependent and conflicts with
+  deterministic domain projections.
+- **Strategy enum** (`early`, `mid`, `late`, `same`) — replaced by a single
+  per-person `claim_age_months` field.
+- **WEP / `pension_eligible`** — WEP was repealed in 2025; the rebuild uses only
+  the standard PIA formula.
+
+Deferred to later phases:
+
+- Taxation of Social Security benefits (Phase 2d).
+- Inflation application to benefit streams (Phase 3 simulation layer).
+- SSA XML upload, plan persistence wiring from uploaded files, and editor UX
+  (Phase 4).
+
+---
+
+## 2. Decisions captured from brainstorming
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **Claim age only** (`claim_age_months`) | Keeps SS deterministic and compatible with pre-simulation domain projections |
+| 2 | **Drop net-worth claiming** | It requires monthly simulation state (`net_worth`) and cannot be precomputed into a static domain series |
+| 3 | **Keep spousal benefit behavior** | It is meaningful for single-earner-heavy households and remains deterministic once claim ages are fixed |
+| 4 | **Use real-aware earnings indexing** | Future job income from Phase 2b is already in today's dollars; indexing it again would undercount |
+| 5 | **Use SSA XML FICA earnings for historical values** | SSA exports the user's official SS-covered earnings; `FicaEarnings` is capped, while `MedicareEarnings` is not |
+| 6 | **Include pure parser in Phase 2c; defer upload UI** | Parser is core domain/input logic; UI wiring belongs with Phase 4 editor/import work |
+| 7 | **Use monthly claim-age formula relative to FRA 67** | More accurate than legacy integer-age lookup and supports mid-year claiming |
+| 8 | **Drop WEP / `pension_eligible`** | WEP repeal makes the reduced 40/32/15 legacy path obsolete |
+| 9 | **Return projected series, not `TimedStream`s** | Spousal step-ups and selected max benefit are clearer as deterministic monthly series |
+| 10 | **Store `spousal_alternative`; compute `spousal_top_up`** | Keeps output intuitive while avoiding duplicate source-of-truth fields |
+
+---
+
+## 3. Config models (`core`)
+
+Social Security config lives in `core` because `Plan` persists it through the
+existing JSON-blob repository, exactly like jobs and timed streams.
+
+```python
+from decimal import Decimal
+from pydantic import BaseModel, Field
+
+
+class AnnualEarnings(BaseModel):
+    """One SSA historical annual FICA earnings row.
+
+    FICA earnings from the SSA XML are SS-covered and already capped at that
+    calendar year's taxable maximum. Values are nominal historical dollars.
+    """
+
+    year: int
+    fica_earnings: Decimal = Field(ge=0)
+
+
+class SocialSecurity(BaseModel):
+    """Per-person Social Security calculation inputs."""
+
+    claim_age_months: int = Field(default=67 * 12, ge=62 * 12, le=70 * 12)
+    trust_factor: Decimal = Field(default=Decimal(1), ge=0, le=1)
+    earnings_record: list[AnnualEarnings] = Field(default_factory=list)
+```
+
+`PersonHousehold` gains one field:
+
+```python
+class PersonHousehold(BaseModel):
+    birth_month: int = Field(ge=1, le=12)
+    birth_year: int
+    max_age_years: int = Field(default=100, ge=1)
+    jobs: list[Job] = Field(default_factory=list)
+    social_security: SocialSecurity = Field(default_factory=SocialSecurity)
+```
+
+The default claim age is 67 years because the rebuild targets current users born
+in 1960 or later, where Full Retirement Age is 67. General FRA-by-birth-year
+support can be added later if the app needs to model older cohorts.
+
+---
+
+## 4. SSA XML parser
+
+Phase 2c adds a pure parser that converts SSA's exportable Online Social
+Security Statement XML into `list[AnnualEarnings]`.
+
+```python
+def parse_social_security_statement_xml(xml_text: str) -> list[AnnualEarnings]: ...
+```
+
+Parser rules:
+
+- Accept the `http://ssa.gov/osss/schemas/2.0` namespace.
+- Read `EarningsRecord/Earnings` rows.
+- Require `startYear == endYear`; multi-year rows raise `ValueError`.
+- Extract `FicaEarnings`; ignore `MedicareEarnings`.
+- Skip `FicaEarnings == -1`, which SSA uses for years not yet recorded.
+- Reject malformed rows and non-numeric values with useful `ValueError`
+  messages.
+- Ignore `EstimatedBenefits` for calculations.
+
+`EstimatedBenefits` are not used because SSA's estimates assume continued work
+under SSA's own assumptions. They can be useful later as reference metadata or a
+sanity check, but the app's plan-driven calculation must respond to early
+retirement, sabbaticals, and future jobs configured in LifeFinances.
+
+---
+
+## 5. Earnings pipeline
+
+`project_social_security(plan, timeline, job_income)` combines two earnings
+sources per person:
+
+1. Historical `AnnualEarnings` from SSA XML, in nominal dollars.
+2. Future projected `job_income.person*.ss_covered_gross`, in today's dollars.
+
+The pipeline is real-aware:
+
+1. Group future monthly `ss_covered_gross` by calendar year using `timeline`.
+2. Convert historical earnings to today's dollars using AWI indexing factors.
+3. Leave future projected earnings at face value because they are already real,
+   today's-dollar values from Phase 2b.
+4. Apply the Social Security taxable maximum cap per year in the same dollar
+   basis as the earnings being capped.
+5. Compute AIME from the highest 35 annual indexed earnings years, including
+   implicit zero years when fewer than 35 years have earnings.
+6. Compute PIA from standard bend points and rates.
+
+Historical FICA earnings from SSA XML are already capped for their source year,
+but the calculation still routes all earnings through a single cap step so tests
+can prove the invariant and future earnings are capped consistently.
+
+### Constants and extrapolation
+
+Phase 2c ports the legacy Social Security data tables for:
+
+- historical taxable maximum (`SS_MAX_EARNINGS`);
+- AWI indexing factors (`SS_INDEXES`);
+- bend points;
+- PIA rates.
+
+The legacy code used NumPy exponential fit helpers. The rebuild should not add
+NumPy just for this phase; implement a small stdlib log-linear least-squares
+helper for exponential extrapolation. The helper takes source table rows
+`(year, value)` and returns an estimated value for a requested year, matching the
+legacy shape without importing legacy app code.
+
+---
+
+## 6. PIA and claim-age calculation
+
+AIME is:
+
+```text
+sum(top_35_indexed_annual_earnings) / 420
+```
+
+PIA uses the standard bend-point formula:
+
+```text
+90% of AIME up to the first bend point
+32% of AIME between the first and second bend points
+15% of AIME above the second bend point
+```
+
+WEP / `pension_eligible` is not ported.
+
+The benefit multiplier is a monthly formula relative to Full Retirement Age 67:
+
+- Claim before FRA:
+  - reduce by `5/9%` per month for the first 36 months early;
+  - reduce by `5/12%` per month for months earlier than that.
+- Claim after FRA:
+  - increase by `2/3%` per delayed month through age 70.
+
+`claim_age_months` is constrained to `[62 * 12, 70 * 12]`, so no extrapolation
+beyond SSA's early/delayed retirement bounds is required.
+
+Each person's own monthly benefit starts in the calendar month they reach
+`claim_age_months`:
+
+```text
+own_benefit = PIA * claim_age_multiplier * trust_factor
+```
+
+Amounts are projected as real monthly dollars. Inflation is applied later by the
+simulation layer, not in the domain calculation.
+
+---
+
+## 7. Spousal alternatives
+
+Phase 2c keeps the legacy spousal behavior, adapted to deterministic claim ages.
+
+Once both spouses have claimed, each person can receive a spousal alternative:
+
+```text
+spousal_alternative = 0.5 * spouse_pia * person's_claim_age_multiplier * trust_factor
+```
+
+Before both people have claimed, `spousal_alternative` is zero. A person's total
+benefit is the month-by-month maximum of their own benefit and spousal
+alternative:
+
+```text
+total = max(own_benefit, spousal_alternative)
+```
+
+The spousal alternative uses the worker's own claim-age multiplier, matching the
+legacy behavior: the spouse's PIA defines the base, but the worker's claiming
+age determines the reduction or delayed credit applied to the worker's benefit.
+
+---
+
+## 8. Output: `SocialSecurityProjection`
+
+```python
+from decimal import Decimal
+from pydantic import BaseModel, computed_field
+
+
+class PersonSocialSecurity(BaseModel):
+    """Projected Social Security for one person.
+
+    All series have length == timeline.horizon_months and are after trust-factor
+    scaling. spousal_alternative is the full alternative benefit, not only the
+    incremental amount above own_benefit.
+    """
+
+    own_benefit: list[Decimal]
+    spousal_alternative: list[Decimal]
+    total: list[Decimal]
+
+    @computed_field
+    @property
+    def spousal_top_up(self) -> list[Decimal]:
+        return [
+            total - own
+            for own, total in zip(self.own_benefit, self.total, strict=True)
+        ]
+
+
+class SocialSecurityProjection(BaseModel):
+    person1: PersonSocialSecurity
+    person2: PersonSocialSecurity
+    total: list[Decimal]
+```
+
+Public API:
+
+```python
+def project_social_security(
+    plan: Plan,
+    timeline: Timeline,
+    job_income: JobIncomeProjection,
+) -> SocialSecurityProjection: ...
+```
+
+The module consumes the Phase 2b `JobIncomeProjection` instead of recomputing job
+income. This proves that sabbatical-reduced SS-covered earnings flow through SS
+without duplicating job-income logic.
+
+---
+
+## 9. File layout
+
+```text
+packages/core/
+├── core/
+│   ├── social_security.py   # NEW — AnnualEarnings, SocialSecurity
+│   └── models.py            # + PersonHousehold.social_security
+└── tests/
+    └── test_social_security.py
+
+packages/domain/
+├── domain/
+│   └── social_security/
+│       ├── __init__.py      # project_social_security, output models
+│       ├── earnings.py      # XML parser + earnings/AIME helpers
+│       └── benefits.py      # PIA + monthly claim-age multiplier
+├── tests/
+│   └── test_social_security.py
+└── OVERVIEW.md              # social_security status -> done when complete
+```
+
+Exact module names can be adjusted during planning, but responsibilities should
+stay separated: parser/earnings, benefit formula, and projection orchestration.
+
+---
+
+## 10. Error handling
+
+| Situation | Behavior |
+|-----------|----------|
+| `claim_age_months` outside 62-70 | Pydantic `ValidationError` |
+| `trust_factor` outside `[0, 1]` | Pydantic `ValidationError` |
+| negative `AnnualEarnings.fica_earnings` | Pydantic `ValidationError`; parser skips only SSA's `-1` sentinel before model construction |
+| SSA XML missing `EarningsRecord` | `ValueError` with a clear message |
+| SSA XML row has `startYear != endYear` | `ValueError` with the row years |
+| SSA XML row has malformed `FicaEarnings` | `ValueError` with the year when available |
+| no earnings history and no future SS-covered earnings | PIA is zero; output series are all zero |
+| one spouse has zero PIA | their own benefit is zero; spouse's alternative from them is zero |
+| timeline has non-positive horizon | output lists are empty, matching `project_stream` behavior |
+
+---
+
+## 11. Testing (TDD, one behavior per test)
+
+Per repo testing policy: behavior test first, scaffold to a logical red, then
+implement. Inject `today: date`. Pull shared values from source; never duplicate
+a literal across arrange and assert.
+
+Representative behaviors:
+
+| Area | Behaviors |
+|------|-----------|
+| Core models | default claim age is FRA 67; claim age bounds enforced; trust factor bounds enforced; repository round-trip persists earnings records |
+| XML parser | extracts FICA earnings; ignores Medicare earnings; skips `-1`; handles SSA namespace; rejects missing/malformed/multi-year rows |
+| Earnings aggregation | future monthly `ss_covered_gross` groups by calendar year; historical earnings are indexed; future real earnings are not indexed |
+| Wage-base cap | annual earnings above the taxable max are capped before AIME |
+| AIME | uses top 35 years; includes implicit zero years when fewer than 35 earnings years exist |
+| PIA | standard 90/32/15 bend-point formula; no WEP path |
+| Claim multiplier | monthly early/delayed formulas at 62, FRA, 70, and a mid-year claim age |
+| Claim start | benefits begin in the exact calendar month the person reaches `claim_age_months` |
+| Spousal alternative | zero before both people claim; present after both claim; total is max(own, alternative) |
+| Trust factor | scales both own benefit and spousal alternative for the person receiving benefits |
+| Job-income integration | sabbatical-reduced `ss_covered_gross` changes future earnings and therefore AIME/PIA |
+| Projection shape | per-person lists and household total have `timeline.horizon_months` length |
+
+Do **not** test pure Pydantic validation of trivial fields beyond the model
+contracts listed above.
+
+---
+
+## 12. Exit criteria
+
+- [ ] `AnnualEarnings` and `SocialSecurity` models in `core`.
+- [ ] `PersonHousehold.social_security` persists through SQLite round-trip.
+- [ ] SSA statement XML parser extracts historical FICA earnings and skips `-1`.
+- [ ] `project_social_security(plan, timeline, job_income)` returns
+      `SocialSecurityProjection`.
+- [ ] Real-aware earnings pipeline: historical earnings indexed, future real
+      earnings not indexed.
+- [ ] Future SS earnings consume Phase 2b `ss_covered_gross`; sabbatical-reduced
+      earnings flow through.
+- [ ] AIME/PIA calculation uses standard formula only; WEP not ported.
+- [ ] Monthly claim-age formula supports claim ages from 62 through 70.
+- [ ] Spousal alternatives and computed `spousal_top_up` covered by tests.
+- [ ] `packages/domain/OVERVIEW.md` documents SS port status.
+- [ ] `make` passes.
+
+---
+
+## 13. Deferred
+
+- SSA XML upload UI, parser wiring from uploaded files into saved plans, and
+  editor UX.
+- Taxation of Social Security benefits.
+- Inflation application in simulation outputs.
+- Optional parsing/storage of SSA `EstimatedBenefits` as reference metadata.
+
+## 14. Next step
+
+After spec approval: invoke **writing-plans** to produce
+`docs/superpowers/plans/2026-06-12-phase-2c-domain-social-security.md`, then
+execute via subagent-driven development.

--- a/docs/superpowers/specs/2026-06-23-phase-2c-domain-social-security-design.md
+++ b/docs/superpowers/specs/2026-06-23-phase-2c-domain-social-security-design.md
@@ -19,8 +19,8 @@ job income. The output is a month-indexed `SocialSecurityProjection`, mirroring
 
 Phase 2c includes:
 
-1. **Plan-config models** for Social Security claim age, trust factor, and
-   historical annual FICA earnings.
+1. **Plan-config models** for per-person Social Security claim age and
+   historical annual FICA earnings, plus one household-level trust factor.
 2. A **pure SSA statement XML parser** that extracts historical capped FICA
    earnings from SSA's exportable XML.
 3. A **real-aware benefit calculation**: historical nominal earnings are indexed
@@ -64,6 +64,7 @@ Deferred to later phases:
 | 8 | **Drop WEP / `pension_eligible`** | WEP repeal makes the reduced 40/32/15 legacy path obsolete |
 | 9 | **Return projected series, not `TimedStream`s** | Spousal step-ups and selected max benefit are clearer as deterministic monthly series |
 | 10 | **Store `spousal_alternative`; compute `spousal_top_up`** | Keeps output intuitive while avoiding duplicate source-of-truth fields |
+| 11 | **Use one household-level SS trust factor** | Trust is an assumption about the Social Security system, not person-specific data; applying one factor to PIA is equivalent to applying it later to all benefits |
 
 ---
 
@@ -88,15 +89,15 @@ class AnnualEarnings(BaseModel):
     fica_earnings: Decimal = Field(ge=0)
 
 
-class SocialSecurity(BaseModel):
+class PersonSocialSecurityConfig(BaseModel):
     """Per-person Social Security calculation inputs."""
 
     claim_age_months: int = Field(default=67 * 12, ge=62 * 12, le=70 * 12)
-    trust_factor: Decimal = Field(default=Decimal(1), ge=0, le=1)
     earnings_record: list[AnnualEarnings] = Field(default_factory=list)
 ```
 
-`PersonHousehold` gains one field:
+`PersonHousehold` gains one field, and `Household` gains one household-level
+trust factor:
 
 ```python
 class PersonHousehold(BaseModel):
@@ -104,12 +105,27 @@ class PersonHousehold(BaseModel):
     birth_year: int
     max_age_years: int = Field(default=100, ge=1)
     jobs: list[Job] = Field(default_factory=list)
-    social_security: SocialSecurity = Field(default_factory=SocialSecurity)
+    social_security: PersonSocialSecurityConfig = Field(
+        default_factory=PersonSocialSecurityConfig
+    )
+
+
+class Household(BaseModel):
+    person1: PersonHousehold
+    person2: PersonHousehold
+    social_security_trust_factor: Decimal = Field(default=Decimal(1), ge=0, le=1)
 ```
 
 The default claim age is 67 years because the rebuild targets current users born
 in 1960 or later, where Full Retirement Age is 67. General FRA-by-birth-year
 support can be added later if the app needs to model older cohorts.
+
+`social_security_trust_factor` is a household-level assumption about future
+Social Security payments. It applies once to each person's statutory PIA to
+produce an effective PIA used by both own-benefit and spousal-alternative
+calculations. Because the same factor applies to both people, this is
+mathematically equivalent to multiplying the final selected household benefits,
+while keeping downstream projected series in expected received dollars.
 
 ---
 
@@ -208,6 +224,12 @@ PIA uses the standard bend-point formula:
 
 WEP / `pension_eligible` is not ported.
 
+The household trust factor is then applied to produce effective PIA:
+
+```text
+effective_pia = statutory_pia * household.social_security_trust_factor
+```
+
 The benefit multiplier is a monthly formula relative to Full Retirement Age 67:
 
 - Claim before FRA:
@@ -223,7 +245,7 @@ Each person's own monthly benefit starts in the calendar month they reach
 `claim_age_months`:
 
 ```text
-own_benefit = PIA * claim_age_multiplier * trust_factor
+own_benefit = effective_pia * claim_age_multiplier
 ```
 
 Amounts are projected as real monthly dollars. Inflation is applied later by the
@@ -238,7 +260,7 @@ Phase 2c keeps the legacy spousal behavior, adapted to deterministic claim ages.
 Once both spouses have claimed, each person can receive a spousal alternative:
 
 ```text
-spousal_alternative = 0.5 * spouse_pia * person's_claim_age_multiplier * trust_factor
+spousal_alternative = 0.5 * spouse_effective_pia * person's_claim_age_multiplier
 ```
 
 Before both people have claimed, `spousal_alternative` is zero. A person's total
@@ -265,9 +287,9 @@ from pydantic import BaseModel, computed_field
 class PersonSocialSecurity(BaseModel):
     """Projected Social Security for one person.
 
-    All series have length == timeline.horizon_months and are after trust-factor
-    scaling. spousal_alternative is the full alternative benefit, not only the
-    incremental amount above own_benefit.
+    All series have length == timeline.horizon_months and are after household
+    trust-factor scaling. spousal_alternative is the full alternative benefit,
+    not only the incremental amount above own_benefit.
     """
 
     own_benefit: list[Decimal]
@@ -310,8 +332,8 @@ without duplicating job-income logic.
 ```text
 packages/core/
 ├── core/
-│   ├── social_security.py   # NEW — AnnualEarnings, SocialSecurity
-│   └── models.py            # + PersonHousehold.social_security
+│   ├── social_security.py   # NEW — AnnualEarnings, PersonSocialSecurityConfig
+│   └── models.py            # + PersonHousehold.social_security; + Household.social_security_trust_factor
 └── tests/
     └── test_social_security.py
 
@@ -340,7 +362,7 @@ projection orchestration.
 | Situation | Behavior |
 |-----------|----------|
 | `claim_age_months` outside 62-70 | Pydantic `ValidationError` |
-| `trust_factor` outside `[0, 1]` | Pydantic `ValidationError` |
+| `social_security_trust_factor` outside `[0, 1]` | Pydantic `ValidationError` |
 | negative `AnnualEarnings.fica_earnings` | Pydantic `ValidationError`; parser skips only SSA's `-1` sentinel before model construction |
 | SSA XML missing `EarningsRecord` | `ValueError` with a clear message |
 | SSA XML row has `startYear != endYear` | `ValueError` with the row years |
@@ -361,7 +383,7 @@ Representative behaviors:
 
 | Area | Behaviors |
 |------|-----------|
-| Core models | default claim age is FRA 67; claim age bounds enforced; trust factor bounds enforced; repository round-trip persists earnings records |
+| Core models | default claim age is FRA 67; claim age bounds enforced; household trust factor bounds enforced; repository round-trip persists earnings records |
 | XML parser | extracts FICA earnings; ignores Medicare earnings; skips `-1`; handles SSA namespace; rejects missing/malformed/multi-year rows |
 | Earnings aggregation | future monthly `ss_covered_gross` groups by calendar year; historical earnings are indexed; future real earnings are not indexed |
 | Statutory tables | SS tables live under `domain/statutory`; tests import source constants instead of duplicating literals |
@@ -371,7 +393,7 @@ Representative behaviors:
 | Claim multiplier | monthly early/delayed formulas at 62, FRA, 70, and a mid-year claim age |
 | Claim start | benefits begin in the exact calendar month the person reaches `claim_age_months` |
 | Spousal alternative | zero before both people claim; present after both claim; total is max(own, alternative) |
-| Trust factor | scales both own benefit and spousal alternative for the person receiving benefits |
+| Trust factor | household trust factor scales effective PIA and therefore both own benefit and spousal alternative |
 | Job-income integration | sabbatical-reduced `ss_covered_gross` changes future earnings and therefore AIME/PIA |
 | Projection shape | per-person lists and household total have `timeline.horizon_months` length |
 
@@ -382,8 +404,9 @@ contracts listed above.
 
 ## 12. Exit criteria
 
-- [ ] `AnnualEarnings` and `SocialSecurity` models in `core`.
-- [ ] `PersonHousehold.social_security` persists through SQLite round-trip.
+- [ ] `AnnualEarnings` and `PersonSocialSecurityConfig` models in `core`.
+- [ ] `PersonHousehold.social_security` and `Household.social_security_trust_factor`
+      persist through SQLite round-trip.
 - [ ] SSA statement XML parser extracts historical FICA earnings and skips `-1`.
 - [ ] Social Security statutory tables live under `domain/statutory`, setting the
       pattern for future tax-rate tables.

--- a/docs/superpowers/specs/2026-06-23-phase-2c-domain-social-security-design.md
+++ b/docs/superpowers/specs/2026-06-23-phase-2c-domain-social-security-design.md
@@ -164,14 +164,23 @@ Historical FICA earnings from SSA XML are already capped for their source year,
 but the calculation still routes all earnings through a single cap step so tests
 can prove the invariant and future earnings are capped consistently.
 
-### Constants and extrapolation
+### Statutory tables and extrapolation
 
-Phase 2c ports the legacy Social Security data tables for:
+Phase 2c establishes the statutory-data pattern that later tax work can reuse.
+Regularly updated statutory inputs live in `domain`, not `core`, because they are
+calculation inputs rather than persisted plan configuration.
+
+Social Security tables live under `domain/statutory/` and include:
 
 - historical taxable maximum (`SS_MAX_EARNINGS`);
 - AWI indexing factors (`SS_INDEXES`);
 - bend points;
 - PIA rates.
+
+The tables are versioned source data checked into the repository, not fetched
+live from SSA at runtime. Each table should carry source URLs, effective year,
+and last-updated notes. Updates happen through normal code/data PRs so
+simulations remain reproducible.
 
 The legacy code used NumPy exponential fit helpers. The rebuild should not add
 NumPy just for this phase; implement a small stdlib log-linear least-squares
@@ -308,6 +317,9 @@ packages/core/
 
 packages/domain/
 ├── domain/
+│   ├── statutory/
+│   │   ├── __init__.py
+│   │   └── social_security.py  # SS taxable max, AWI, bend points, PIA rates
 │   └── social_security/
 │       ├── __init__.py      # project_social_security, output models
 │       ├── earnings.py      # XML parser + earnings/AIME helpers
@@ -318,7 +330,8 @@ packages/domain/
 ```
 
 Exact module names can be adjusted during planning, but responsibilities should
-stay separated: parser/earnings, benefit formula, and projection orchestration.
+stay separated: statutory tables, parser/earnings, benefit formula, and
+projection orchestration.
 
 ---
 
@@ -351,6 +364,7 @@ Representative behaviors:
 | Core models | default claim age is FRA 67; claim age bounds enforced; trust factor bounds enforced; repository round-trip persists earnings records |
 | XML parser | extracts FICA earnings; ignores Medicare earnings; skips `-1`; handles SSA namespace; rejects missing/malformed/multi-year rows |
 | Earnings aggregation | future monthly `ss_covered_gross` groups by calendar year; historical earnings are indexed; future real earnings are not indexed |
+| Statutory tables | SS tables live under `domain/statutory`; tests import source constants instead of duplicating literals |
 | Wage-base cap | annual earnings above the taxable max are capped before AIME |
 | AIME | uses top 35 years; includes implicit zero years when fewer than 35 earnings years exist |
 | PIA | standard 90/32/15 bend-point formula; no WEP path |
@@ -371,6 +385,8 @@ contracts listed above.
 - [ ] `AnnualEarnings` and `SocialSecurity` models in `core`.
 - [ ] `PersonHousehold.social_security` persists through SQLite round-trip.
 - [ ] SSA statement XML parser extracts historical FICA earnings and skips `-1`.
+- [ ] Social Security statutory tables live under `domain/statutory`, setting the
+      pattern for future tax-rate tables.
 - [ ] `project_social_security(plan, timeline, job_income)` returns
       `SocialSecurityProjection`.
 - [ ] Real-aware earnings pipeline: historical earnings indexed, future real

--- a/packages/core/core/models.py
+++ b/packages/core/core/models.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from pydantic import BaseModel, Field, model_validator
 
 from core.job import Job
+from core.social_security import PersonSocialSecurityConfig
 from core.streams import TimedStream
 from core.timeline import boundary_to_year_month
 
@@ -37,11 +38,15 @@ class PersonHousehold(BaseModel):
     birth_year: int
     max_age_years: int = Field(default=100, ge=1)
     jobs: list[Job] = Field(default_factory=list)
+    social_security: PersonSocialSecurityConfig = Field(
+        default_factory=PersonSocialSecurityConfig
+    )
 
 
 class Household(BaseModel):
     person1: PersonHousehold
     person2: PersonHousehold
+    social_security_trust_factor: Decimal = Field(default=Decimal(1), ge=0, le=1)
 
     @model_validator(mode="after")
     def _validate_sabbatical_windows(self) -> Household:

--- a/packages/core/core/social_security.py
+++ b/packages/core/core/social_security.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+MIN_CLAIM_AGE_MONTHS = 62 * 12
+FULL_RETIREMENT_AGE_MONTHS = 67 * 12
+MAX_CLAIM_AGE_MONTHS = 70 * 12
+
+
+class AnnualEarnings(BaseModel):
+    """One SSA historical annual FICA earnings row."""
+
+    year: int
+    fica_earnings: Decimal = Field(ge=0)
+
+
+class PersonSocialSecurityConfig(BaseModel):
+    """Per-person Social Security calculation inputs."""
+
+    claim_age_months: int = Field(
+        default=FULL_RETIREMENT_AGE_MONTHS,
+        ge=MIN_CLAIM_AGE_MONTHS,
+        le=MAX_CLAIM_AGE_MONTHS,
+    )
+    earnings_record: list[AnnualEarnings] = Field(default_factory=list)

--- a/packages/core/tests/test_social_security.py
+++ b/packages/core/tests/test_social_security.py
@@ -1,0 +1,96 @@
+# packages/core/tests/test_social_security.py
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from core.defaults import default_plan
+from core.models import Household, PersonHousehold, Plan
+from core.repository import PlanRepository
+from core.social_security import (
+    FULL_RETIREMENT_AGE_MONTHS,
+    MAX_CLAIM_AGE_MONTHS,
+    MIN_CLAIM_AGE_MONTHS,
+    AnnualEarnings,
+    PersonSocialSecurityConfig,
+)
+from pydantic import ValidationError
+
+
+def test_default_plan_has_social_security_defaults() -> None:
+    plan = default_plan()
+
+    assert plan.household.person1.social_security.claim_age_months == (
+        FULL_RETIREMENT_AGE_MONTHS
+    )
+    assert plan.household.person2.social_security.claim_age_months == (
+        FULL_RETIREMENT_AGE_MONTHS
+    )
+    assert plan.household.social_security_trust_factor == Decimal("1")
+
+
+def test_claim_age_must_be_between_62_and_70() -> None:
+    too_early = MIN_CLAIM_AGE_MONTHS - 1
+    too_late = MAX_CLAIM_AGE_MONTHS + 1
+
+    with pytest.raises(ValidationError):
+        PersonSocialSecurityConfig(claim_age_months=too_early)
+
+    with pytest.raises(ValidationError):
+        PersonSocialSecurityConfig(claim_age_months=too_late)
+
+
+def test_household_trust_factor_must_be_between_zero_and_one() -> None:
+    base = default_plan().household
+    too_high = Decimal("1.01")
+
+    with pytest.raises(ValidationError):
+        Household(
+            person1=base.person1,
+            person2=base.person2,
+            social_security_trust_factor=too_high,
+        )
+
+
+def test_social_security_config_round_trips_through_repository(
+    repo: PlanRepository,
+) -> None:
+    plan_id, plan = repo.get_or_create_default()
+    expected_claim_age = MIN_CLAIM_AGE_MONTHS
+    expected_trust = Decimal("0.76")
+    expected_earnings = [
+        AnnualEarnings(year=2023, fica_earnings=Decimal("160200")),
+        AnnualEarnings(year=2024, fica_earnings=Decimal("52700")),
+    ]
+
+    updated_plan = Plan(
+        name=plan.name,
+        household=Household(
+            person1=PersonHousehold(
+                birth_month=plan.household.person1.birth_month,
+                birth_year=plan.household.person1.birth_year,
+                max_age_years=plan.household.person1.max_age_years,
+                jobs=plan.household.person1.jobs,
+                social_security=PersonSocialSecurityConfig(
+                    claim_age_months=expected_claim_age,
+                    earnings_record=expected_earnings,
+                ),
+            ),
+            person2=plan.household.person2,
+            social_security_trust_factor=expected_trust,
+        ),
+        portfolio=plan.portfolio,
+        manual_income_streams=plan.manual_income_streams,
+    )
+
+    repo.save(plan_id, updated_plan)
+    loaded = repo.get_by_id(plan_id)
+
+    assert loaded is not None
+    assert loaded.household.person1.social_security.claim_age_months == (
+        expected_claim_age
+    )
+    assert loaded.household.person1.social_security.earnings_record == (
+        expected_earnings
+    )
+    assert loaded.household.social_security_trust_factor == expected_trust

--- a/packages/domain/OVERVIEW.md
+++ b/packages/domain/OVERVIEW.md
@@ -23,7 +23,7 @@ projected with `core.timeline.project_stream`. See the Phase 2a design spec:
 | Legacy module | Destination | Phase | Status |
 |---------------|-------------|-------|--------|
 | `job_income.py` (incl. planned sabbaticals) | `domain/job_income/` | 2b | done |
-| `social_security.py` | `domain/social_security/` | 2c | not started |
+| `social_security.py` | `domain/social_security/` | 2c | done |
 | `pension.py` | `domain/pension/` | 2d | not started |
 | `taxes.py` (income-side) | `domain/taxes/` | 2d | not started |
 | `build_monthly_cashflows(plan)` aggregator | `domain/__init__.py` | 2d | not started |

--- a/packages/domain/domain/social_security/__init__.py
+++ b/packages/domain/domain/social_security/__init__.py
@@ -1,0 +1,1 @@
+"""Social Security domain projection."""

--- a/packages/domain/domain/social_security/__init__.py
+++ b/packages/domain/domain/social_security/__init__.py
@@ -81,10 +81,34 @@ def _person_inputs(
     )
 
 
+def _zeroes(horizon: int) -> list[Decimal]:
+    return [Decimal("0.00")] * horizon
+
+
 def _own_series(inputs: _PersonInputs, horizon: int) -> list[Decimal]:
-    series = [Decimal("0.00")] * horizon
+    series = _zeroes(horizon)
     monthly = (inputs.effective_pia * inputs.claim_multiplier).quantize(_CENTS)
     low = max(inputs.claim_start_index, 0)
+    for month_index in range(low, horizon):
+        series[month_index] = monthly
+    return series
+
+
+def _spousal_series(
+    *,
+    receiver_inputs: _PersonInputs,
+    spouse_inputs: _PersonInputs,
+    horizon: int,
+) -> list[Decimal]:
+    SPOUSAL_RATIO = Decimal("0.5")
+    series = _zeroes(horizon)
+    start_index = max(
+        receiver_inputs.claim_start_index, spouse_inputs.claim_start_index
+    )
+    monthly = (
+        spouse_inputs.effective_pia * SPOUSAL_RATIO * receiver_inputs.claim_multiplier
+    ).quantize(_CENTS)
+    low = max(start_index, 0)
     for month_index in range(low, horizon):
         series[month_index] = monthly
     return series
@@ -126,12 +150,20 @@ def project_social_security(
         future_ss_covered=job_income.person2.ss_covered_gross,
         trust_factor=trust_factor,
     )
-    person1 = _person_projection(
-        _own_series(person1_inputs, horizon), [Decimal("0.00")] * horizon
+    person1_own = _own_series(person1_inputs, horizon)
+    person2_own = _own_series(person2_inputs, horizon)
+    person1_spousal = _spousal_series(
+        receiver_inputs=person1_inputs,
+        spouse_inputs=person2_inputs,
+        horizon=horizon,
     )
-    person2 = _person_projection(
-        _own_series(person2_inputs, horizon), [Decimal("0.00")] * horizon
+    person2_spousal = _spousal_series(
+        receiver_inputs=person2_inputs,
+        spouse_inputs=person1_inputs,
+        horizon=horizon,
     )
+    person1 = _person_projection(person1_own, person1_spousal)
+    person2 = _person_projection(person2_own, person2_spousal)
     return SocialSecurityProjection(
         person1=person1,
         person2=person2,

--- a/packages/domain/domain/social_security/__init__.py
+++ b/packages/domain/domain/social_security/__init__.py
@@ -1,1 +1,141 @@
-"""Social Security domain projection."""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from core.models import PersonHousehold, Plan
+from core.streams import PersonAgeBoundary, PersonId
+from core.timeline import Timeline
+from pydantic import BaseModel, computed_field
+
+from domain.job_income import JobIncomeProjection
+from domain.social_security.benefits import (
+    calculate_aime,
+    calculate_pia,
+    claim_age_multiplier,
+)
+from domain.social_security.earnings import (
+    group_monthly_earnings_by_year,
+    indexed_annual_earnings,
+)
+
+_CENTS = Decimal("0.01")
+
+
+class PersonSocialSecurity(BaseModel):
+    """Projected Social Security for one person."""
+
+    own_benefit: list[Decimal]
+    spousal_alternative: list[Decimal]
+    max_benefit: list[Decimal]
+
+    @computed_field
+    @property
+    def spousal_top_up(self) -> list[Decimal]:
+        return [
+            benefit - own
+            for own, benefit in zip(self.own_benefit, self.max_benefit, strict=True)
+        ]
+
+
+class SocialSecurityProjection(BaseModel):
+    person1: PersonSocialSecurity
+    person2: PersonSocialSecurity
+    total: list[Decimal]
+
+
+class _PersonInputs(BaseModel):
+    pia: Decimal
+    effective_pia: Decimal
+    claim_multiplier: Decimal
+    claim_start_index: int
+
+
+def _person_inputs(
+    *,
+    person: PersonHousehold,
+    person_id: PersonId,
+    timeline: Timeline,
+    future_ss_covered: list[Decimal],
+    trust_factor: Decimal,
+) -> _PersonInputs:
+    future_by_year = group_monthly_earnings_by_year(future_ss_covered, timeline)
+    earnings = indexed_annual_earnings(
+        historical_earnings=person.social_security.earnings_record,
+        future_real_earnings_by_year=future_by_year,
+        today_year=timeline.today.year,
+    )
+    pia = calculate_pia(calculate_aime(earnings)) if earnings else Decimal("0.00")
+    effective_pia = (pia * trust_factor).quantize(_CENTS)
+    claim_multiplier = claim_age_multiplier(person.social_security.claim_age_months)
+    claim_start_index = timeline.index_of(
+        PersonAgeBoundary(
+            person=person_id,
+            age_months=person.social_security.claim_age_months,
+        )
+    )
+    return _PersonInputs(
+        pia=pia,
+        effective_pia=effective_pia,
+        claim_multiplier=claim_multiplier,
+        claim_start_index=claim_start_index,
+    )
+
+
+def _own_series(inputs: _PersonInputs, horizon: int) -> list[Decimal]:
+    series = [Decimal("0.00")] * horizon
+    monthly = (inputs.effective_pia * inputs.claim_multiplier).quantize(_CENTS)
+    low = max(inputs.claim_start_index, 0)
+    for month_index in range(low, horizon):
+        series[month_index] = monthly
+    return series
+
+
+def _person_projection(
+    own_benefit: list[Decimal],
+    spousal_alternative: list[Decimal],
+) -> PersonSocialSecurity:
+    max_benefit = [
+        max(own, spousal)
+        for own, spousal in zip(own_benefit, spousal_alternative, strict=True)
+    ]
+    return PersonSocialSecurity(
+        own_benefit=own_benefit,
+        spousal_alternative=spousal_alternative,
+        max_benefit=max_benefit,
+    )
+
+
+def project_social_security(
+    plan: Plan,
+    timeline: Timeline,
+    job_income: JobIncomeProjection,
+) -> SocialSecurityProjection:
+    horizon = timeline.horizon_months
+    trust_factor = plan.household.social_security_trust_factor
+    person1_inputs = _person_inputs(
+        person=plan.household.person1,
+        person_id="person1",
+        timeline=timeline,
+        future_ss_covered=job_income.person1.ss_covered_gross,
+        trust_factor=trust_factor,
+    )
+    person2_inputs = _person_inputs(
+        person=plan.household.person2,
+        person_id="person2",
+        timeline=timeline,
+        future_ss_covered=job_income.person2.ss_covered_gross,
+        trust_factor=trust_factor,
+    )
+    person1 = _person_projection(
+        _own_series(person1_inputs, horizon), [Decimal("0.00")] * horizon
+    )
+    person2 = _person_projection(
+        _own_series(person2_inputs, horizon), [Decimal("0.00")] * horizon
+    )
+    return SocialSecurityProjection(
+        person1=person1,
+        person2=person2,
+        total=[
+            a + b for a, b in zip(person1.max_benefit, person2.max_benefit, strict=True)
+        ],
+    )

--- a/packages/domain/domain/social_security/__init__.py
+++ b/packages/domain/domain/social_security/__init__.py
@@ -58,14 +58,7 @@ def _person_inputs(
     future_ss_covered: list[Decimal],
     trust_factor: Decimal,
 ) -> _PersonInputs:
-    claim_start_index = timeline.index_of(
-        PersonAgeBoundary(
-            person=person_id,
-            age_months=person.social_security.claim_age_months,
-        )
-    )
-    earning_months = future_ss_covered[: max(claim_start_index, 0)]
-    future_by_year = group_monthly_earnings_by_year(earning_months, timeline)
+    future_by_year = group_monthly_earnings_by_year(future_ss_covered, timeline)
     earnings = indexed_annual_earnings(
         historical_earnings=person.social_security.earnings_record,
         future_real_earnings_by_year=future_by_year,
@@ -74,6 +67,12 @@ def _person_inputs(
     pia = calculate_pia(calculate_aime(earnings)) if earnings else Decimal("0.00")
     effective_pia = (pia * trust_factor).quantize(_CENTS)
     claim_multiplier = claim_age_multiplier(person.social_security.claim_age_months)
+    claim_start_index = timeline.index_of(
+        PersonAgeBoundary(
+            person=person_id,
+            age_months=person.social_security.claim_age_months,
+        )
+    )
     return _PersonInputs(
         pia=pia,
         effective_pia=effective_pia,

--- a/packages/domain/domain/social_security/__init__.py
+++ b/packages/domain/domain/social_security/__init__.py
@@ -58,7 +58,14 @@ def _person_inputs(
     future_ss_covered: list[Decimal],
     trust_factor: Decimal,
 ) -> _PersonInputs:
-    future_by_year = group_monthly_earnings_by_year(future_ss_covered, timeline)
+    claim_start_index = timeline.index_of(
+        PersonAgeBoundary(
+            person=person_id,
+            age_months=person.social_security.claim_age_months,
+        )
+    )
+    earning_months = future_ss_covered[: max(claim_start_index, 0)]
+    future_by_year = group_monthly_earnings_by_year(earning_months, timeline)
     earnings = indexed_annual_earnings(
         historical_earnings=person.social_security.earnings_record,
         future_real_earnings_by_year=future_by_year,
@@ -67,12 +74,6 @@ def _person_inputs(
     pia = calculate_pia(calculate_aime(earnings)) if earnings else Decimal("0.00")
     effective_pia = (pia * trust_factor).quantize(_CENTS)
     claim_multiplier = claim_age_multiplier(person.social_security.claim_age_months)
-    claim_start_index = timeline.index_of(
-        PersonAgeBoundary(
-            person=person_id,
-            age_months=person.social_security.claim_age_months,
-        )
-    )
     return _PersonInputs(
         pia=pia,
         effective_pia=effective_pia,

--- a/packages/domain/domain/social_security/benefits.py
+++ b/packages/domain/domain/social_security/benefits.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from core.social_security import FULL_RETIREMENT_AGE_MONTHS
+
+from domain.statutory.social_security import CURRENT_BEND_POINTS, PIA_RATES
+
+_CENTS = Decimal("0.01")
+
+
+def calculate_aime(indexed_annual_earnings: list[Decimal]) -> Decimal:
+    """Average indexed monthly earnings from highest 35 annual earnings years."""
+    top_years = sorted(indexed_annual_earnings, reverse=True)[:35]
+    if len(top_years) < 35:
+        top_years = [*top_years, *([Decimal("0")] * (35 - len(top_years)))]
+    return sum(top_years) / Decimal(35 * 12)
+
+
+def calculate_pia(aime: Decimal) -> Decimal:
+    """Primary Insurance Amount using the standard 90/32/15 formula."""
+    first_bend, second_bend = CURRENT_BEND_POINTS
+    rate1, rate2, rate3 = PIA_RATES
+    first_slice = min(aime, first_bend)
+    second_slice = min(max(aime - first_bend, Decimal("0")), second_bend - first_bend)
+    third_slice = max(aime - second_bend, Decimal("0"))
+    return (first_slice * rate1 + second_slice * rate2 + third_slice * rate3).quantize(
+        _CENTS
+    )
+
+
+def claim_age_multiplier(claim_age_months: int) -> Decimal:
+    """Monthly early/delayed retirement multiplier relative to FRA 67."""
+    if claim_age_months < FULL_RETIREMENT_AGE_MONTHS:
+        months_early = FULL_RETIREMENT_AGE_MONTHS - claim_age_months
+        first_36 = min(months_early, 36)
+        additional = max(months_early - 36, 0)
+        reduction = Decimal(first_36) * Decimal(5) / Decimal(900) + Decimal(
+            additional
+        ) * Decimal(5) / Decimal(1200)
+        return Decimal("1") - reduction
+    months_delayed = claim_age_months - FULL_RETIREMENT_AGE_MONTHS
+    return Decimal("1") + Decimal(months_delayed) * Decimal(2) / Decimal(300)

--- a/packages/domain/domain/social_security/earnings.py
+++ b/packages/domain/domain/social_security/earnings.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from xml.etree import ElementTree
+
+from core.social_security import AnnualEarnings
+
+_NAMESPACE = {"osss": "http://ssa.gov/osss/schemas/2.0"}
+
+
+def _required_text(element: ElementTree.Element, path: str, year: int) -> str:
+    child = element.find(path, _NAMESPACE)
+    if child is None or child.text is None:
+        raise ValueError(f"missing {path} for SSA earnings year {year}")
+    return child.text.strip()
+
+
+def parse_social_security_statement_xml(xml_text: str) -> list[AnnualEarnings]:
+    """Parse SSA statement XML into annual capped FICA earnings."""
+    try:
+        root = ElementTree.fromstring(xml_text)
+    except ElementTree.ParseError as exc:
+        raise ValueError("invalid SSA statement XML") from exc
+
+    record = root.find("osss:EarningsRecord", _NAMESPACE)
+    if record is None:
+        raise ValueError("SSA statement XML is missing EarningsRecord")
+
+    earnings: list[AnnualEarnings] = []
+    for row in record.findall("osss:Earnings", _NAMESPACE):
+        start_year_raw = row.attrib.get("startYear")
+        end_year_raw = row.attrib.get("endYear")
+        if start_year_raw is None or end_year_raw is None:
+            raise ValueError("SSA earnings row is missing startYear or endYear")
+        start_year = int(start_year_raw)
+        end_year = int(end_year_raw)
+        if start_year != end_year:
+            raise ValueError(f"SSA earnings row is multi-year: {start_year}-{end_year}")
+        fica_text = _required_text(row, "osss:FicaEarnings", start_year)
+        try:
+            fica_earnings = Decimal(fica_text)
+        except InvalidOperation as exc:
+            raise ValueError(
+                f"malformed FicaEarnings for SSA earnings year {start_year}"
+            ) from exc
+        if fica_earnings == Decimal("-1"):
+            continue
+        earnings.append(AnnualEarnings(year=start_year, fica_earnings=fica_earnings))
+    return earnings

--- a/packages/domain/domain/social_security/earnings.py
+++ b/packages/domain/domain/social_security/earnings.py
@@ -4,6 +4,13 @@ from decimal import Decimal, InvalidOperation
 from xml.etree import ElementTree
 
 from core.social_security import AnnualEarnings
+from core.timeline import Timeline
+
+from domain.statutory.social_security import (
+    AWI_INDEX_BY_YEAR,
+    SS_MAX_EARNINGS_BY_YEAR,
+    statutory_value_for_year,
+)
 
 _NAMESPACE = {"osss": "http://ssa.gov/osss/schemas/2.0"}
 
@@ -47,3 +54,41 @@ def parse_social_security_statement_xml(xml_text: str) -> list[AnnualEarnings]:
             continue
         earnings.append(AnnualEarnings(year=start_year, fica_earnings=fica_earnings))
     return earnings
+
+
+def group_monthly_earnings_by_year(
+    monthly_earnings: list[Decimal],
+    timeline: Timeline,
+) -> dict[int, Decimal]:
+    grouped: dict[int, Decimal] = {}
+    for month_index, earnings in enumerate(monthly_earnings):
+        boundary = timeline.month_boundary(month_index)
+        grouped[boundary.year] = grouped.get(boundary.year, Decimal("0")) + earnings
+    return grouped
+
+
+def _indexed_taxable_max(year: int) -> Decimal:
+    nominal_max = statutory_value_for_year(SS_MAX_EARNINGS_BY_YEAR, year)
+    index = statutory_value_for_year(AWI_INDEX_BY_YEAR, year)
+    return nominal_max * index
+
+
+def indexed_annual_earnings(
+    *,
+    historical_earnings: list[AnnualEarnings],
+    future_real_earnings_by_year: dict[int, Decimal],
+    today_year: int,
+) -> list[Decimal]:
+    values: list[Decimal] = []
+    for row in historical_earnings:
+        capped_nominal = min(
+            row.fica_earnings,
+            statutory_value_for_year(SS_MAX_EARNINGS_BY_YEAR, row.year),
+        )
+        index = statutory_value_for_year(AWI_INDEX_BY_YEAR, row.year)
+        values.append(capped_nominal * index)
+    for year, earnings in future_real_earnings_by_year.items():
+        if year < today_year:
+            continue
+        values.append(min(earnings, _indexed_taxable_max(year)))
+    return values

--- a/packages/domain/domain/statutory/__init__.py
+++ b/packages/domain/domain/statutory/__init__.py
@@ -1,0 +1,1 @@
+"""Versioned statutory tables used by domain calculations."""

--- a/packages/domain/domain/statutory/social_security.py
+++ b/packages/domain/domain/statutory/social_security.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import math
+from decimal import Decimal
+
+# Update procedure: once a year, verify each value below against its source URL,
+# refresh any that changed, then set LAST_REVIEWED_YEAR to the current year.
+# `is_statutory_data_stale` turns this into a soft CI reminder (see below).
+LAST_REVIEWED_YEAR = 2026
+STALENESS_GRACE_YEARS = 2
+
+# Append-only historical records: each year's row is permanent. Add a new row
+# each year; never edit prior rows.
+SOURCE_NOTES = {
+    "taxable_max": "SSA maximum taxable earnings (append-only history): https://www.ssa.gov/benefits/retirement/planner/maxtax.html",
+    "awi_index": "SSA indexing factors (append-only history): https://www.ssa.gov/cgi-bin/awiFactors.cgi",
+    "current_bend_points": "SSA bend points (single current set, replaced yearly): https://www.ssa.gov/oact/cola/bendpoints.html",
+    "pia_rates": "SSA PIA formula (single current set): https://www.ssa.gov/oact/cola/piaformula.html",
+}
+
+SS_MAX_EARNINGS_BY_YEAR: tuple[tuple[int, Decimal], ...] = (
+    (2002, Decimal("84900")),
+    (2003, Decimal("87000")),
+    (2004, Decimal("87900")),
+    (2005, Decimal("90000")),
+    (2006, Decimal("94200")),
+    (2007, Decimal("97500")),
+    (2008, Decimal("102000")),
+    (2009, Decimal("106800")),
+    (2010, Decimal("106800")),
+    (2011, Decimal("106800")),
+    (2012, Decimal("110100")),
+    (2013, Decimal("113700")),
+    (2014, Decimal("117000")),
+    (2015, Decimal("118500")),
+    (2016, Decimal("118500")),
+    (2017, Decimal("127200")),
+    (2018, Decimal("128400")),
+    (2019, Decimal("132900")),
+    (2020, Decimal("137700")),
+    (2021, Decimal("142800")),
+    (2022, Decimal("147000")),
+    (2023, Decimal("160200")),
+    (2024, Decimal("168600")),
+    (2025, Decimal("176100")),
+    (2026, Decimal("184500")),
+)
+
+AWI_INDEX_BY_YEAR: tuple[tuple[int, Decimal], ...] = (
+    (2003, Decimal("1.9557287")),
+    (2004, Decimal("1.8688502")),
+    (2005, Decimal("1.8028823")),
+    (2006, Decimal("1.7236577")),
+    (2007, Decimal("1.6488308")),
+    (2008, Decimal("1.6117539")),
+    (2009, Decimal("1.6364325")),
+    (2010, Decimal("1.5986484")),
+    (2011, Decimal("1.5500792")),
+    (2012, Decimal("1.5031428")),
+    (2013, Decimal("1.4841731")),
+    (2014, Decimal("1.4332965")),
+    (2015, Decimal("1.3851081")),
+    (2016, Decimal("1.3696311")),
+    (2017, Decimal("1.3239129")),
+    (2018, Decimal("1.2776063")),
+    (2019, Decimal("1.2314568")),
+    (2020, Decimal("1.1976178")),
+    (2021, Decimal("1.0998221")),
+    (2022, Decimal("1.0443086")),
+    (2023, Decimal("1.0000000")),
+    (2024, Decimal("1.0000000")),
+)
+
+# Single current sets, not historical records: replace these in place each year.
+CURRENT_BEND_POINTS: tuple[Decimal, Decimal] = (Decimal("1286"), Decimal("7749"))
+PIA_RATES: tuple[Decimal, Decimal, Decimal] = (
+    Decimal("0.90"),
+    Decimal("0.32"),
+    Decimal("0.15"),
+)
+
+
+def is_statutory_data_stale(current_year: int) -> bool:
+    """Whether statutory data is overdue for its annual review.
+
+    Soft reminder: stale only once `current_year` reaches
+    `LAST_REVIEWED_YEAR + STALENESS_GRACE_YEARS`, so a new calendar year alone
+    does not break CI while values are still close enough (real-dollar bend
+    points barely move year to year).
+    """
+    return current_year - LAST_REVIEWED_YEAR >= STALENESS_GRACE_YEARS
+
+
+def log_linear_extrapolate(
+    rows: tuple[tuple[int, Decimal], ...] | list[tuple[int, Decimal]],
+    year: int,
+) -> Decimal:
+    """Estimate `value(year)` from `(year, value)` rows using log-linear fit."""
+    if not rows:
+        raise ValueError("cannot extrapolate an empty statutory table")
+    for source_year, value in rows:
+        if source_year == year:
+            return value
+    x_values = [float(source_year) for source_year, _ in rows]
+    y_values = [math.log(float(value)) for _, value in rows]
+    x_mean = sum(x_values) / len(x_values)
+    y_mean = sum(y_values) / len(y_values)
+    numerator = sum(
+        (x_value - x_mean) * (y_value - y_mean)
+        for x_value, y_value in zip(x_values, y_values, strict=True)
+    )
+    denominator = sum((x_value - x_mean) ** 2 for x_value in x_values)
+    if denominator == 0:
+        return rows[0][1]
+    slope = numerator / denominator
+    intercept = y_mean - slope * x_mean
+    return Decimal(str(math.exp(intercept + slope * float(year))))
+
+
+def statutory_value_for_year(
+    rows: tuple[tuple[int, Decimal], ...],
+    year: int,
+) -> Decimal:
+    """Return exact statutory value when available, otherwise extrapolate."""
+    return log_linear_extrapolate(rows, year)

--- a/packages/domain/tests/test_social_security.py
+++ b/packages/domain/tests/test_social_security.py
@@ -4,6 +4,8 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
+from core.social_security import AnnualEarnings
+from domain.social_security.earnings import parse_social_security_statement_xml
 from domain.statutory.social_security import (
     AWI_INDEX_BY_YEAR,
     CURRENT_BEND_POINTS,
@@ -63,3 +65,45 @@ def test_log_linear_extrapolate_extends_two_year_growth() -> None:
 
     expected = second_value * (second_value / first_value)
     assert float(result) == pytest.approx(float(expected), rel=0.0001)
+
+
+def test_parse_social_security_statement_xml_extracts_fica_earnings() -> None:
+    xml_text = """<?xml version="1.0" encoding="UTF-8"?>
+<osss:OnlineSocialSecurityStatementData xmlns:osss="http://ssa.gov/osss/schemas/2.0">
+  <osss:EarningsRecord>
+    <osss:Earnings startYear="2023" endYear="2023">
+      <osss:FicaEarnings>160200</osss:FicaEarnings>
+      <osss:MedicareEarnings>219491</osss:MedicareEarnings>
+    </osss:Earnings>
+    <osss:Earnings startYear="2025" endYear="2025">
+      <osss:FicaEarnings>-1</osss:FicaEarnings>
+      <osss:MedicareEarnings>-1</osss:MedicareEarnings>
+    </osss:Earnings>
+  </osss:EarningsRecord>
+</osss:OnlineSocialSecurityStatementData>
+"""
+    expected = [AnnualEarnings(year=2023, fica_earnings=Decimal("160200"))]
+    earnings = parse_social_security_statement_xml(xml_text)
+    assert earnings == expected
+
+
+def test_parse_social_security_statement_xml_rejects_multi_year_rows() -> None:
+    xml_text = """<?xml version="1.0" encoding="UTF-8"?>
+<osss:OnlineSocialSecurityStatementData xmlns:osss="http://ssa.gov/osss/schemas/2.0">
+  <osss:EarningsRecord>
+    <osss:Earnings startYear="2020" endYear="2021">
+      <osss:FicaEarnings>1000</osss:FicaEarnings>
+    </osss:Earnings>
+  </osss:EarningsRecord>
+</osss:OnlineSocialSecurityStatementData>
+"""
+    with pytest.raises(ValueError, match="multi-year"):
+        parse_social_security_statement_xml(xml_text)
+
+
+def test_parse_social_security_statement_xml_rejects_missing_record() -> None:
+    xml_text = """<?xml version="1.0" encoding="UTF-8"?>
+<osss:OnlineSocialSecurityStatementData xmlns:osss="http://ssa.gov/osss/schemas/2.0" />
+"""
+    with pytest.raises(ValueError, match="EarningsRecord"):
+        parse_social_security_statement_xml(xml_text)

--- a/packages/domain/tests/test_social_security.py
+++ b/packages/domain/tests/test_social_security.py
@@ -5,8 +5,16 @@ from decimal import Decimal
 
 import pytest
 from core.defaults import default_plan
-from core.social_security import FULL_RETIREMENT_AGE_MONTHS, AnnualEarnings
+from core.models import Household, PersonHousehold, Plan, Portfolio
+from core.social_security import (
+    FULL_RETIREMENT_AGE_MONTHS,
+    AnnualEarnings,
+    PersonSocialSecurityConfig,
+)
+from core.streams import PersonAgeBoundary, PersonId
 from core.timeline import Timeline
+from domain.job_income import JobIncomeProjection, PersonJobIncome
+from domain.social_security import project_social_security
 from domain.social_security.benefits import (
     calculate_aime,
     calculate_pia,
@@ -185,3 +193,75 @@ def test_indexed_annual_earnings_indexes_history_but_not_future_real_income() ->
     expected_history = historical_earning * historical_index
     assert expected_history in earnings
     assert future[future_year] in earnings
+
+
+def _zero_job_income(horizon: int) -> JobIncomeProjection:
+    zeroes = [Decimal("0.00")] * horizon
+    person = PersonJobIncome(gross=zeroes, ss_covered_gross=zeroes, tax_deferred=zeroes)
+    return JobIncomeProjection(
+        person1=person,
+        person2=person,
+        total_gross=zeroes,
+        total_ss_covered_gross=zeroes,
+        total_tax_deferred=zeroes,
+    )
+
+
+def _ss_plan(
+    *,
+    person1_claim_age_months: int = FULL_RETIREMENT_AGE_MONTHS,
+    person2_claim_age_months: int = FULL_RETIREMENT_AGE_MONTHS,
+    trust_factor: Decimal = Decimal("1"),
+) -> Plan:
+    return Plan(
+        name="SS Test Plan",
+        household=Household(
+            person1=PersonHousehold(
+                birth_month=1,
+                birth_year=1960,
+                social_security=PersonSocialSecurityConfig(
+                    claim_age_months=person1_claim_age_months,
+                    earnings_record=[
+                        AnnualEarnings(year=2023, fica_earnings=Decimal("160200"))
+                    ],
+                ),
+            ),
+            person2=PersonHousehold(
+                birth_month=1,
+                birth_year=1962,
+                social_security=PersonSocialSecurityConfig(
+                    claim_age_months=person2_claim_age_months,
+                ),
+            ),
+            social_security_trust_factor=trust_factor,
+        ),
+        portfolio=Portfolio(current_savings_balance=Decimal("0")),
+    )
+
+
+def test_project_social_security_returns_horizon_length_series() -> None:
+    plan = _ss_plan()
+    timeline = Timeline(plan, today=date(2026, 1, 1))
+    job_income = _zero_job_income(timeline.horizon_months)
+
+    projection = project_social_security(plan, timeline, job_income)
+
+    assert len(projection.person1.max_benefit) == timeline.horizon_months
+    assert len(projection.person2.max_benefit) == timeline.horizon_months
+    assert len(projection.total) == timeline.horizon_months
+
+
+def test_project_social_security_starts_own_benefit_at_claim_month() -> None:
+    claim_age = 67 * 12
+    plan = _ss_plan(person1_claim_age_months=claim_age)
+    timeline = Timeline(plan, today=date(2026, 1, 1))
+    job_income = _zero_job_income(timeline.horizon_months)
+    person_id: PersonId = "person1"
+    claim_index = timeline.index_of(
+        PersonAgeBoundary(person=person_id, age_months=claim_age)
+    )
+
+    projection = project_social_security(plan, timeline, job_income)
+
+    assert projection.person1.own_benefit[claim_index - 1] == Decimal("0.00")
+    assert projection.person1.own_benefit[claim_index] > Decimal("0.00")

--- a/packages/domain/tests/test_social_security.py
+++ b/packages/domain/tests/test_social_security.py
@@ -265,3 +265,51 @@ def test_project_social_security_starts_own_benefit_at_claim_month() -> None:
 
     assert projection.person1.own_benefit[claim_index - 1] == Decimal("0.00")
     assert projection.person1.own_benefit[claim_index] > Decimal("0.00")
+
+
+def test_spousal_alternative_starts_after_both_people_claim() -> None:
+    person1_claim = 67 * 12
+    person2_claim = 70 * 12
+    plan = _ss_plan(
+        person1_claim_age_months=person1_claim,
+        person2_claim_age_months=person2_claim,
+    )
+    plan.household.person2.social_security.earnings_record = [
+        AnnualEarnings(year=2023, fica_earnings=Decimal("160200"))
+    ]
+    timeline = Timeline(plan, today=date(2026, 1, 1))
+    job_income = _zero_job_income(timeline.horizon_months)
+    person1_claim_index = timeline.index_of(
+        PersonAgeBoundary(person="person1", age_months=person1_claim)
+    )
+    person2_claim_index = timeline.index_of(
+        PersonAgeBoundary(person="person2", age_months=person2_claim)
+    )
+
+    projection = project_social_security(plan, timeline, job_income)
+
+    assert projection.person1.spousal_alternative[person1_claim_index] == (
+        Decimal("0.00")
+    )
+    assert projection.person1.spousal_alternative[person2_claim_index] > (
+        Decimal("0.00")
+    )
+
+
+def test_spousal_top_up_is_max_benefit_minus_own_benefit() -> None:
+    plan = _ss_plan()
+    plan.household.person2.social_security.earnings_record = [
+        AnnualEarnings(year=2023, fica_earnings=Decimal("160200"))
+    ]
+    timeline = Timeline(plan, today=date(2026, 1, 1))
+    job_income = _zero_job_income(timeline.horizon_months)
+
+    projection = project_social_security(plan, timeline, job_income)
+
+    for own, max_benefit, top_up in zip(
+        projection.person1.own_benefit,
+        projection.person1.max_benefit,
+        projection.person1.spousal_top_up,
+        strict=True,
+    ):
+        assert top_up == max_benefit - own

--- a/packages/domain/tests/test_social_security.py
+++ b/packages/domain/tests/test_social_security.py
@@ -5,15 +5,16 @@ from decimal import Decimal
 
 import pytest
 from core.defaults import default_plan
+from core.job import Job, SabbaticalWindow
 from core.models import Household, PersonHousehold, Plan, Portfolio
 from core.social_security import (
     FULL_RETIREMENT_AGE_MONTHS,
     AnnualEarnings,
     PersonSocialSecurityConfig,
 )
-from core.streams import PersonAgeBoundary, PersonId
+from core.streams import CalendarMonthBoundary, PersonAgeBoundary, PersonId
 from core.timeline import Timeline
-from domain.job_income import JobIncomeProjection, PersonJobIncome
+from domain.job_income import JobIncomeProjection, PersonJobIncome, project_job_income
 from domain.social_security import project_social_security
 from domain.social_security.benefits import (
     calculate_aime,
@@ -313,3 +314,92 @@ def test_spousal_top_up_is_max_benefit_minus_own_benefit() -> None:
         strict=True,
     ):
         assert top_up == max_benefit - own
+
+
+def test_sabbatical_reduced_ss_covered_income_flows_into_projection() -> None:
+    annual_income = Decimal("120000")
+    claim_age_months = 67 * 12
+    break_start = CalendarMonthBoundary(year=2026, month=1)
+    break_end = CalendarMonthBoundary(year=2026, month=12)
+    person_with_break = PersonHousehold(
+        birth_month=1,
+        birth_year=1990,
+        social_security=PersonSocialSecurityConfig(claim_age_months=claim_age_months),
+        jobs=[
+            Job(
+                annual_income=annual_income,
+                social_security_eligible=True,
+                sabbaticals=[
+                    SabbaticalWindow(
+                        start=break_start,
+                        end=break_end,
+                        remaining_fraction=Decimal("0"),
+                    )
+                ],
+            )
+        ],
+    )
+    person_without_break = PersonHousehold(
+        birth_month=1,
+        birth_year=1990,
+        social_security=PersonSocialSecurityConfig(claim_age_months=claim_age_months),
+        jobs=[Job(annual_income=annual_income, social_security_eligible=True)],
+    )
+    base = default_plan()
+    plan_with_break = Plan(
+        name="SS Sabbatical",
+        household=Household(person1=person_with_break, person2=base.household.person2),
+        portfolio=base.portfolio,
+    )
+    plan_without_break = Plan(
+        name="SS No Sabbatical",
+        household=Household(
+            person1=person_without_break, person2=base.household.person2
+        ),
+        portfolio=base.portfolio,
+    )
+    timeline_with_break = Timeline(plan_with_break, today=date(2026, 1, 1))
+    timeline_without_break = Timeline(plan_without_break, today=date(2026, 1, 1))
+
+    projection_with_break = project_social_security(
+        plan_with_break,
+        timeline_with_break,
+        project_job_income(plan_with_break, timeline_with_break),
+    )
+    projection_without_break = project_social_security(
+        plan_without_break,
+        timeline_without_break,
+        project_job_income(plan_without_break, timeline_without_break),
+    )
+
+    claim_index = timeline_with_break.index_of(
+        PersonAgeBoundary(person="person1", age_months=claim_age_months)
+    )
+    assert (
+        projection_with_break.person1.own_benefit[claim_index]
+        < (projection_without_break.person1.own_benefit[claim_index])
+    )
+
+
+def test_household_trust_factor_scales_projected_benefits() -> None:
+    full_trust = Decimal("1")
+    reduced_trust = Decimal("0.75")
+    full_plan = _ss_plan(trust_factor=full_trust)
+    reduced_plan = _ss_plan(trust_factor=reduced_trust)
+    full_timeline = Timeline(full_plan, today=date(2026, 1, 1))
+    reduced_timeline = Timeline(reduced_plan, today=date(2026, 1, 1))
+    full_projection = project_social_security(
+        full_plan, full_timeline, _zero_job_income(full_timeline.horizon_months)
+    )
+    reduced_projection = project_social_security(
+        reduced_plan,
+        reduced_timeline,
+        _zero_job_income(reduced_timeline.horizon_months),
+    )
+    claim_index = full_timeline.index_of(
+        PersonAgeBoundary(person="person1", age_months=67 * 12)
+    )
+
+    assert reduced_projection.person1.max_benefit[claim_index] == (
+        full_projection.person1.max_benefit[claim_index] * reduced_trust
+    ).quantize(Decimal("0.01"))

--- a/packages/domain/tests/test_social_security.py
+++ b/packages/domain/tests/test_social_security.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from domain.statutory.social_security import (
+    AWI_INDEX_BY_YEAR,
+    CURRENT_BEND_POINTS,
+    LAST_REVIEWED_YEAR,
+    PIA_RATES,
+    SS_MAX_EARNINGS_BY_YEAR,
+    STALENESS_GRACE_YEARS,
+    is_statutory_data_stale,
+    log_linear_extrapolate,
+    statutory_value_for_year,
+)
+
+
+def test_statutory_tables_sanity_checks() -> None:
+    pinned_taxable_max = Decimal("176100")
+    # Contract test: 2025 SSA taxable maximum is intentionally pinned as a sanity check.
+    assert statutory_value_for_year(SS_MAX_EARNINGS_BY_YEAR, 2025) == (
+        pinned_taxable_max
+    )
+    assert all(isinstance(value, Decimal) for _, value in AWI_INDEX_BY_YEAR)
+    assert CURRENT_BEND_POINTS[0] < CURRENT_BEND_POINTS[1]
+    assert PIA_RATES[0] > PIA_RATES[1]
+    assert PIA_RATES[1] > PIA_RATES[2]
+
+
+def test_statutory_data_is_fresh_within_grace_window() -> None:
+    last_fresh_year = LAST_REVIEWED_YEAR + STALENESS_GRACE_YEARS - 1
+
+    assert is_statutory_data_stale(last_fresh_year) is False
+
+
+def test_statutory_data_is_stale_past_grace_window() -> None:
+    first_stale_year = LAST_REVIEWED_YEAR + STALENESS_GRACE_YEARS
+
+    assert is_statutory_data_stale(first_stale_year) is True
+
+
+def test_statutory_data_is_not_stale_today() -> None:
+    # Intentional real-calendar reminder: when this fails, verify the SSA tables
+    # against their source URLs, refresh any changed values, and bump
+    # LAST_REVIEWED_YEAR.
+    assert is_statutory_data_stale(date.today().year) is False, (
+        "Social Security statutory data is overdue for review; "
+        "verify against source URLs and bump LAST_REVIEWED_YEAR."
+    )
+
+
+def test_log_linear_extrapolate_extends_two_year_growth() -> None:
+    first_year = 2000
+    second_year = 2001
+    first_value = Decimal("100")
+    second_value = Decimal("121")
+    requested_year = 2002
+    source_rows = [(first_year, first_value), (second_year, second_value)]
+
+    result = log_linear_extrapolate(source_rows, requested_year)
+
+    expected = second_value * (second_value / first_value)
+    assert float(result) == pytest.approx(float(expected), rel=0.0001)

--- a/packages/domain/tests/test_social_security.py
+++ b/packages/domain/tests/test_social_security.py
@@ -4,7 +4,12 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
-from core.social_security import AnnualEarnings
+from core.social_security import FULL_RETIREMENT_AGE_MONTHS, AnnualEarnings
+from domain.social_security.benefits import (
+    calculate_aime,
+    calculate_pia,
+    claim_age_multiplier,
+)
 from domain.social_security.earnings import parse_social_security_statement_xml
 from domain.statutory.social_security import (
     AWI_INDEX_BY_YEAR,
@@ -107,3 +112,40 @@ def test_parse_social_security_statement_xml_rejects_missing_record() -> None:
 """
     with pytest.raises(ValueError, match="EarningsRecord"):
         parse_social_security_statement_xml(xml_text)
+
+
+def test_calculate_aime_uses_highest_35_years_with_implicit_zeroes() -> None:
+    earning_years = 10
+    annual_earnings = [Decimal("42000")] * earning_years
+    aime = calculate_aime(annual_earnings)
+    expected = sum(annual_earnings) / Decimal(35 * 12)
+    assert aime == expected
+
+
+def test_calculate_pia_uses_standard_bend_point_formula() -> None:
+    aime = Decimal("9000")
+    pia = calculate_pia(aime)
+    first_bend, second_bend = CURRENT_BEND_POINTS
+    rate1, rate2, rate3 = PIA_RATES
+    expected = (
+        first_bend * rate1
+        + (second_bend - first_bend) * rate2
+        + (aime - second_bend) * rate3
+    ).quantize(Decimal("0.01"))
+    assert pia == expected
+
+
+def test_claim_age_multiplier_uses_monthly_early_and_delayed_rules() -> None:
+    fra_multiplier = Decimal("1")
+    earliest_claim_age = 62 * 12
+    delayed_claim_age = 70 * 12
+    early = claim_age_multiplier(earliest_claim_age)
+    fra = claim_age_multiplier(FULL_RETIREMENT_AGE_MONTHS)
+    delayed = claim_age_multiplier(delayed_claim_age)
+    first_36_months = Decimal(36) * Decimal(5) / Decimal(900)
+    remaining_24_months = Decimal(24) * Decimal(5) / Decimal(1200)
+    expected_early = Decimal("1") - first_36_months - remaining_24_months
+    expected_delayed = Decimal("1") + Decimal(36) * Decimal(2) / Decimal(300)
+    assert early == expected_early
+    assert fra == fra_multiplier
+    assert delayed == expected_delayed

--- a/packages/domain/tests/test_social_security.py
+++ b/packages/domain/tests/test_social_security.py
@@ -319,6 +319,7 @@ def test_spousal_top_up_is_max_benefit_minus_own_benefit() -> None:
 def test_sabbatical_reduced_ss_covered_income_flows_into_projection() -> None:
     annual_income = Decimal("120000")
     claim_age_months = 67 * 12
+    career_end = CalendarMonthBoundary(year=2040, month=12)
     break_start = CalendarMonthBoundary(year=2026, month=1)
     break_end = CalendarMonthBoundary(year=2026, month=12)
     person_with_break = PersonHousehold(
@@ -329,6 +330,7 @@ def test_sabbatical_reduced_ss_covered_income_flows_into_projection() -> None:
             Job(
                 annual_income=annual_income,
                 social_security_eligible=True,
+                end=career_end,
                 sabbaticals=[
                     SabbaticalWindow(
                         start=break_start,
@@ -343,7 +345,13 @@ def test_sabbatical_reduced_ss_covered_income_flows_into_projection() -> None:
         birth_month=1,
         birth_year=1990,
         social_security=PersonSocialSecurityConfig(claim_age_months=claim_age_months),
-        jobs=[Job(annual_income=annual_income, social_security_eligible=True)],
+        jobs=[
+            Job(
+                annual_income=annual_income,
+                social_security_eligible=True,
+                end=career_end,
+            )
+        ],
     )
     base = default_plan()
     plan_with_break = Plan(

--- a/packages/domain/tests/test_social_security.py
+++ b/packages/domain/tests/test_social_security.py
@@ -4,13 +4,19 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
+from core.defaults import default_plan
 from core.social_security import FULL_RETIREMENT_AGE_MONTHS, AnnualEarnings
+from core.timeline import Timeline
 from domain.social_security.benefits import (
     calculate_aime,
     calculate_pia,
     claim_age_multiplier,
 )
-from domain.social_security.earnings import parse_social_security_statement_xml
+from domain.social_security.earnings import (
+    group_monthly_earnings_by_year,
+    indexed_annual_earnings,
+    parse_social_security_statement_xml,
+)
 from domain.statutory.social_security import (
     AWI_INDEX_BY_YEAR,
     CURRENT_BEND_POINTS,
@@ -149,3 +155,33 @@ def test_claim_age_multiplier_uses_monthly_early_and_delayed_rules() -> None:
     assert early == expected_early
     assert fra == fra_multiplier
     assert delayed == expected_delayed
+
+
+def test_group_monthly_earnings_by_year_uses_timeline_calendar_months() -> None:
+    plan = default_plan()
+    timeline = Timeline(plan, today=date(2026, 11, 1))
+    year1_month11 = Decimal("100")
+    year1_month12 = Decimal("200")
+    year2_month1 = Decimal("300")
+    monthly = [year1_month11, year1_month12, year2_month1]
+    grouped = group_monthly_earnings_by_year(monthly, timeline)
+    assert grouped == {2026: year1_month11 + year1_month12, 2027: year2_month1}
+
+
+def test_indexed_annual_earnings_indexes_history_but_not_future_real_income() -> None:
+    historical_year = 2023
+    historical_earning = Decimal("1000")
+    future_year = 2026
+    historical = [
+        AnnualEarnings(year=historical_year, fica_earnings=historical_earning)
+    ]
+    future = {future_year: Decimal("2000")}
+    earnings = indexed_annual_earnings(
+        historical_earnings=historical,
+        future_real_earnings_by_year=future,
+        today_year=2026,
+    )
+    historical_index = statutory_value_for_year(AWI_INDEX_BY_YEAR, historical_year)
+    expected_history = historical_earning * historical_index
+    assert expected_history in earnings
+    assert future[future_year] in earnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ life-finances-web = { workspace = true }
 [tool.pytest.ini_options]
 testpaths = ["tests", "packages"]
 pythonpath = ["."]
+addopts = "--import-mode=importlib"
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
## Summary
- Adds core Social Security plan config (claim age, earnings record, household trust factor)
- Implements `domain/statutory` tables with annual-review staleness checks and log-linear extrapolation
- Parses SSA statement XML for historical FICA earnings
- Builds real-aware earnings pipeline, AIME/PIA math, monthly claim-age multipliers, and spousal alternatives
- Exposes `project_social_security()` consuming Phase 2b `JobIncomeProjection`
- Marks Phase 2c complete in docs and domain overview

## Test plan
- [x] `make` passes locally (74 tests, ruff, pyright)
- [x] SSA XML parser smoke-tested against local statement file (untracked)
- [x] Integration tests cover sabbatical-reduced SS-covered income and trust-factor scaling
- [x] Post-claim earnings remain in AIME pipeline (sabbatical test uses bounded career end)


Made with [Cursor](https://cursor.com)