### PR TITLE
feat(simulation): Phase 3d simulation results data layer

### DIFF
--- a/docs/superpowers/plans/2026-06-12-phase-3d-simulation-results.md
+++ b/docs/superpowers/plans/2026-06-12-phase-3d-simulation-results.md
@@ -1,0 +1,1031 @@
+# Phase 3d — Simulation Results Data Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `run_simulation` return a chart-ready public `SimulationResult` (percentile-reduced series + tax-prorated wealth composition by income source), with percentiles configured via `plan.advanced.percentiles`.
+
+**Architecture:** Engine keeps emitting private `RawSimulationResult` (`num_runs × months`). New `aggregate.py` reduces along the run axis with `numpy.percentile`. New `composition.py` builds deterministic remaining-income NPV bands (job / SS / pension / manual) after tax proration. `run_simulation` resolves percentiles (kwarg → plan), aggregates, attaches composition + `start_month`, and returns the public result. No web chart work.
+
+**Tech Stack:** Python 3.14+, uv workspace, NumPy, Pydantic v2, pytest. Package boundary: `simulation → domain, core`.
+
+**Design spec:** `docs/superpowers/specs/2026-07-10-phase-3d-simulation-results-design.md`
+
+**Note:** Spec was approved uncommitted; include it in the first implementation commit (or the PR that lands 3d).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| ---- | -------------- |
+| Create: `packages/simulation/simulation/aggregate.py` | `aggregate_percentiles` + `build_public_result` |
+| Create: `packages/simulation/simulation/composition.py` | Tax proration + per-source bond NPV wealth bands |
+| Modify: `packages/simulation/simulation/result.py` | `RawSimulationResult` + public `SimulationResult`; bump `ENGINE_VERSION` |
+| Modify: `packages/simulation/simulation/engine.py` | Return `RawSimulationResult` |
+| Modify: `packages/simulation/simulation/stub.py` | Wire aggregate + composition; resolve percentiles |
+| Modify: `packages/simulation/simulation/npv.py` | Add shared `backward_npv_including_current` |
+| Modify: `packages/simulation/simulation/preprocess.py` | Use shared NPV helper for income (and essential) bond pass |
+| Modify: `packages/core/core/models.py` | `DEFAULT_PERCENTILES`, `normalize_percentiles`, `AdvancedConfig`, `Plan.advanced` |
+| Modify: `packages/simulation/simulation/__init__.py` | Export public `SimulationResult` only (not `RawSimulationResult`) |
+| Create: `packages/simulation/tests/test_aggregate.py` | Aggregation wiring |
+| Create: `packages/simulation/tests/test_composition.py` | Proration + NPV reconciliation |
+| Create: `packages/core/tests/test_advanced_config.py` | `normalize_percentiles` behavior only |
+| Modify: `packages/simulation/tests/test_result.py` | Public result shape / equality |
+| Modify: `packages/simulation/tests/test_run_simulation.py` | Public contract + override + horizon |
+| Modify: `packages/simulation/tests/test_engine.py` | Import/assert `RawSimulationResult` if needed |
+| Modify: `packages/simulation/OVERVIEW.md`, `README.md` | Parity + public vs raw |
+| Modify: `docs/superpowers/plans/2026-06-12-rebuild-index.md` | Phase 3d exit criteria + active plan |
+
+**No DB migration:** missing `advanced` on stored plan JSON fills via Pydantic default.
+
+**Web stub:** `results_stub.html` uses `result.balance_start[0][0]` — still valid as first percentile × first month. No web code changes required.
+
+---
+
+## Testing policy (AGENTS.md §108–132)
+
+Apply on every task that adds or changes tests:
+
+1. **Our logic only** — do **not** add tests that only exercise Pydantic field defaults, trivial getters, or “`np.percentile` returns what `np.percentile` returns.” In scope: `normalize_percentiles`, field-mapping in `aggregate_percentiles`, tax proration invariants, composition↔preprocess NPV reconciliation, `run_simulation` shape/override/`start_month` contracts.
+2. **Avoid fragile values** — bind any literal used in both arrange and assert to one variable.
+3. **Pull constants from source** — import `DEFAULT_PERCENTILES`, `ENGINE_VERSION`, etc. from production code. Inline literals only when intentionally pinning a contract; comment why.
+4. **TDD flow** — failing test → minimal scaffolding until failure is **logical** (`AssertionError`, `NotImplementedError`, `ValidationError`) → implement → green. Do not checklist a separate “structural failure” pytest run as its own step.
+
+**Spec §9 item 6 (Plan validation):** covered by testing `normalize_percentiles` (shared by the Pydantic validator and the kwarg path) — not by a “default AdvancedConfig equals …” smoke test.
+
+---
+
+### Task 1: `normalize_percentiles` + `AdvancedConfig`
+
+**Files:**
+- Modify: `packages/core/core/models.py`
+- Create: `packages/core/tests/test_advanced_config.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/core/tests/test_advanced_config.py`:
+
+```python
+import pytest
+from core.models import DEFAULT_PERCENTILES, normalize_percentiles
+from pydantic import ValidationError
+from core.models import AdvancedConfig
+
+
+def test_normalize_percentiles_sorts_ascending():
+    unsorted = [90, 5, 50]
+    expected = sorted(unsorted)
+
+    assert normalize_percentiles(unsorted) == expected
+
+
+def test_normalize_percentiles_rejects_empty():
+    with pytest.raises(ValueError, match="non-empty"):
+        normalize_percentiles([])
+
+
+def test_normalize_percentiles_rejects_out_of_range():
+    with pytest.raises(ValueError, match="0..100"):
+        normalize_percentiles([50, 101])
+
+
+def test_advanced_config_uses_normalize_percentiles():
+    # Our validator must apply the same normalization (sort), not leave input order.
+    unsorted = [95, 5, 50]
+    config = AdvancedConfig(percentiles=unsorted)
+
+    assert config.percentiles == normalize_percentiles(unsorted)
+    assert DEFAULT_PERCENTILES == [5, 50, 95]  # pinned: tpaw UI low/mid/high
+```
+
+- [ ] **Step 2: Run tests to verify logical failure**
+
+Run: `uv run pytest packages/core/tests/test_advanced_config.py -v`
+
+Expected: FAIL with `ImportError` / `AttributeError` until scaffolding, then `NotImplementedError` or `ValidationError` / assert failure — not a silent pass. Add empty stubs first if imports fail structurally:
+
+```python
+# scaffolding in models.py until Step 3
+DEFAULT_PERCENTILES = [5, 50, 95]
+
+def normalize_percentiles(value: list[int]) -> list[int]:
+    raise NotImplementedError
+
+class AdvancedConfig(BaseModel):
+    percentiles: list[int] = Field(default_factory=lambda: list(DEFAULT_PERCENTILES))
+```
+
+Re-run until failure is logical (`NotImplementedError` or assertion).
+
+- [ ] **Step 3: Implement**
+
+In `packages/core/core/models.py` (near other config defaults):
+
+```python
+DEFAULT_PERCENTILES = [5, 50, 95]
+
+
+def normalize_percentiles(value: list[int]) -> list[int]:
+    if not value:
+        raise ValueError("percentiles must be non-empty")
+    if any(p < 0 or p > 100 for p in value):
+        raise ValueError("each percentile must be in 0..100")
+    return sorted(value)
+
+
+class AdvancedConfig(BaseModel):
+    percentiles: list[int] = Field(default_factory=lambda: list(DEFAULT_PERCENTILES))
+
+    @field_validator("percentiles")
+    @classmethod
+    def _normalize_percentiles(cls, value: list[int]) -> list[int]:
+        return normalize_percentiles(value)
+```
+
+Add to `Plan`:
+
+```python
+advanced: AdvancedConfig = Field(default_factory=AdvancedConfig)
+```
+
+Ensure `field_validator` is imported from pydantic if not already.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest packages/core/tests/test_advanced_config.py -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/core/models.py packages/core/tests/test_advanced_config.py \
+  docs/superpowers/specs/2026-07-10-phase-3d-simulation-results-design.md
+git commit -m "$(cat <<'EOF'
+feat(core): add plan.advanced.percentiles for simulation results
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Shared `backward_npv_including_current`
+
+**Files:**
+- Modify: `packages/simulation/simulation/npv.py`
+- Modify: `packages/simulation/simulation/preprocess.py`
+- Create: `packages/simulation/tests/test_backward_npv.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/simulation/tests/test_backward_npv.py`:
+
+```python
+import numpy as np
+from simulation.npv import backward_npv_including_current
+
+
+def test_backward_npv_including_current_matches_hand_recurrence():
+    real_series = np.array([10.0, 20.0, 30.0], dtype=np.float64)
+    one_over_1_plus_r = 0.5  # extreme rate so arithmetic is obvious
+
+    # Hand recurrence (last month → first), same as preprocess income pass:
+    # m2: 0 * 0.5 + 30 = 30
+    # m1: 30 * 0.5 + 20 = 35
+    # m0: 35 * 0.5 + 10 = 27.5
+    expected = np.array([27.5, 35.0, 30.0], dtype=np.float64)
+
+    result = backward_npv_including_current(
+        real_series, one_over_1_plus_r=one_over_1_plus_r
+    )
+
+    np.testing.assert_allclose(result, expected)
+```
+
+- [ ] **Step 2: Run test to verify logical failure**
+
+Run: `uv run pytest packages/simulation/tests/test_backward_npv.py -v`
+
+Expected: logical failure (`ImportError` → stub `NotImplementedError`, or `AssertionError`).
+
+Scaffold:
+
+```python
+def backward_npv_including_current(
+    real_series: np.ndarray, *, one_over_1_plus_r: float
+) -> np.ndarray:
+    raise NotImplementedError
+```
+
+- [ ] **Step 3: Implement helper and switch preprocess income/essential**
+
+In `npv.py`:
+
+```python
+def backward_npv_including_current(
+    real_series: np.ndarray, *, one_over_1_plus_r: float
+) -> np.ndarray:
+    """NPV of `real_series[m:]` including month `m`, discounting at a constant rate."""
+    months = real_series.shape[0]
+    out = np.empty(months, dtype=np.float64)
+    running = 0.0
+    for month in range(months - 1, -1, -1):
+        running = running * one_over_1_plus_r + float(real_series[month])
+        out[month] = running
+    return out
+```
+
+In `preprocess.py`, replace the income/essential running accumulators with:
+
+```python
+income_including = backward_npv_including_current(
+    income_real, one_over_1_plus_r=one_over_1p_bonds
+)
+essential_including = backward_npv_including_current(
+    essential_real, one_over_1_plus_r=one_over_1p_bonds
+)
+npv_income = income_including - income_real
+npv_essential = essential_including - essential_real
+```
+
+Keep the discretionary / cumulative loop as-is (portfolio rate varies by month). Import `backward_npv_including_current` from `simulation.npv`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest packages/simulation/tests/test_backward_npv.py \
+  packages/simulation/tests/test_preprocess.py \
+  packages/simulation/tests/test_engine.py -v
+```
+
+Expected: PASS (preprocess/engine behavior unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/simulation/simulation/npv.py \
+  packages/simulation/simulation/preprocess.py \
+  packages/simulation/tests/test_backward_npv.py
+git commit -m "$(cat <<'EOF'
+refactor(simulation): extract shared bond NPV including current month
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Tax proration
+
+**Files:**
+- Create: `packages/simulation/simulation/composition.py`
+- Create: `packages/simulation/tests/test_composition.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/simulation/tests/test_composition.py`:
+
+```python
+import numpy as np
+from simulation.composition import prorate_net_income_by_source
+
+
+def test_prorated_nets_sum_to_net_cashflow_when_gross_positive():
+    gross_job = np.array([80.0], dtype=np.float64)
+    gross_ss = np.array([20.0], dtype=np.float64)
+    gross_pension = np.array([0.0], dtype=np.float64)
+    gross_manual = np.array([0.0], dtype=np.float64)
+    # Domain stores taxes as non-positive.
+    taxes = np.array([-10.0], dtype=np.float64)
+    total_gross = gross_job + gross_ss + gross_pension + gross_manual
+    net_cashflow = total_gross + taxes
+
+    nets = prorate_net_income_by_source(
+        gross_job=gross_job,
+        gross_social_security=gross_ss,
+        gross_pension=gross_pension,
+        gross_manual=gross_manual,
+        taxes=taxes,
+    )
+
+    summed = (
+        nets["job"]
+        + nets["social_security"]
+        + nets["pension"]
+        + nets["manual"]
+    )
+    np.testing.assert_allclose(summed, net_cashflow)
+
+
+def test_proration_zero_gross_month_yields_zero_nets():
+    zeros = np.array([0.0], dtype=np.float64)
+    taxes = np.array([-5.0], dtype=np.float64)  # residual tax ignored for composition
+
+    nets = prorate_net_income_by_source(
+        gross_job=zeros,
+        gross_social_security=zeros.copy(),
+        gross_pension=zeros.copy(),
+        gross_manual=zeros.copy(),
+        taxes=taxes,
+    )
+
+    for series in nets.values():
+        np.testing.assert_allclose(series, zeros)
+```
+
+- [ ] **Step 2: Run tests to verify logical failure**
+
+Run: `uv run pytest packages/simulation/tests/test_composition.py -v`
+
+Scaffold `prorate_net_income_by_source` raising `NotImplementedError`.
+
+- [ ] **Step 3: Implement proration**
+
+In `composition.py`:
+
+```python
+from __future__ import annotations
+
+import numpy as np
+
+_SOURCE_KEYS = ("job", "social_security", "pension", "manual")
+
+
+def prorate_net_income_by_source(
+    *,
+    gross_job: np.ndarray,
+    gross_social_security: np.ndarray,
+    gross_pension: np.ndarray,
+    gross_manual: np.ndarray,
+    taxes: np.ndarray,
+) -> dict[str, np.ndarray]:
+    """Split net income by source. `taxes` are domain-signed (non-positive)."""
+    gross = {
+        "job": gross_job,
+        "social_security": gross_social_security,
+        "pension": gross_pension,
+        "manual": gross_manual,
+    }
+    total_gross = (
+        gross_job + gross_social_security + gross_pension + gross_manual
+    )
+    nets: dict[str, np.ndarray] = {}
+    for key in _SOURCE_KEYS:
+        net = np.zeros_like(total_gross, dtype=np.float64)
+        positive = total_gross > 0.0
+        share = np.zeros_like(total_gross, dtype=np.float64)
+        share[positive] = gross[key][positive] / total_gross[positive]
+        net[positive] = gross[key][positive] + taxes[positive] * share[positive]
+        nets[key] = net
+    return nets
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest packages/simulation/tests/test_composition.py -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/simulation/simulation/composition.py \
+  packages/simulation/tests/test_composition.py
+git commit -m "$(cat <<'EOF'
+feat(simulation): prorate net income by source for wealth composition
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Wealth composition NPV by source
+
+**Files:**
+- Modify: `packages/simulation/simulation/composition.py`
+- Modify: `packages/simulation/tests/test_composition.py`
+
+- [ ] **Step 1: Write the failing reconciliation test**
+
+Append to `test_composition.py`:
+
+```python
+from simulation.composition import wealth_by_income_source
+from simulation.npv import backward_npv_including_current
+
+
+def test_wealth_by_source_sums_to_combined_income_wealth():
+    months = 4
+    gross_job = np.array([100.0, 100.0, 0.0, 0.0], dtype=np.float64)
+    gross_ss = np.array([0.0, 0.0, 50.0, 50.0], dtype=np.float64)
+    zeros = np.zeros(months, dtype=np.float64)
+    taxes = np.array([-20.0, -20.0, -5.0, -5.0], dtype=np.float64)
+    monthly_inflation = 0.0
+    monthly_bond = 0.01
+    one_over = 1.0 / (1.0 + monthly_bond)
+
+    wealth = wealth_by_income_source(
+        gross_job=gross_job,
+        gross_social_security=gross_ss,
+        gross_pension=zeros,
+        gross_manual=zeros,
+        taxes=taxes,
+        monthly_inflation=monthly_inflation,
+        monthly_bond_rate=monthly_bond,
+    )
+
+    nets = prorate_net_income_by_source(
+        gross_job=gross_job,
+        gross_social_security=gross_ss,
+        gross_pension=zeros,
+        gross_manual=zeros,
+        taxes=taxes,
+    )
+    combined_nominal = sum(nets[k] for k in nets)
+    deflator = (1.0 + monthly_inflation) ** np.arange(months, dtype=np.float64)
+    combined_real = combined_nominal / deflator
+    expected_total = backward_npv_including_current(
+        combined_real, one_over_1_plus_r=one_over
+    )
+
+    actual_total = (
+        wealth.job
+        + wealth.social_security
+        + wealth.pension
+        + wealth.manual
+    )
+    np.testing.assert_allclose(actual_total, expected_total)
+```
+
+- [ ] **Step 2: Run test to verify logical failure**
+
+Run: `uv run pytest packages/simulation/tests/test_composition.py::test_wealth_by_source_sums_to_combined_income_wealth -v`
+
+Scaffold:
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class WealthBySource:
+    job: np.ndarray
+    social_security: np.ndarray
+    pension: np.ndarray
+    manual: np.ndarray
+
+
+def wealth_by_income_source(...) -> WealthBySource:
+    raise NotImplementedError
+```
+
+- [ ] **Step 3: Implement**
+
+```python
+from simulation.npv import backward_npv_including_current
+
+
+def wealth_by_income_source(
+    *,
+    gross_job: np.ndarray,
+    gross_social_security: np.ndarray,
+    gross_pension: np.ndarray,
+    gross_manual: np.ndarray,
+    taxes: np.ndarray,
+    monthly_inflation: float,
+    monthly_bond_rate: float,
+) -> WealthBySource:
+    nets = prorate_net_income_by_source(
+        gross_job=gross_job,
+        gross_social_security=gross_social_security,
+        gross_pension=gross_pension,
+        gross_manual=gross_manual,
+        taxes=taxes,
+    )
+    months = gross_job.shape[0]
+    deflator = (1.0 + monthly_inflation) ** np.arange(months, dtype=np.float64)
+    one_over = 1.0 / (1.0 + monthly_bond_rate)
+    bands = {
+        key: backward_npv_including_current(
+            nets[key] / deflator, one_over_1_plus_r=one_over
+        )
+        for key in _SOURCE_KEYS
+    }
+    return WealthBySource(
+        job=bands["job"],
+        social_security=bands["social_security"],
+        pension=bands["pension"],
+        manual=bands["manual"],
+    )
+```
+
+- [ ] **Step 4: Run composition tests**
+
+Run: `uv run pytest packages/simulation/tests/test_composition.py -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/simulation/simulation/composition.py \
+  packages/simulation/tests/test_composition.py
+git commit -m "$(cat <<'EOF'
+feat(simulation): build tax-prorated wealth composition NPV by source
+
+EOF
+)"
+```
+
+---
+
+### Task 5: Split result types + percentile aggregation
+
+**Files:**
+- Modify: `packages/simulation/simulation/result.py`
+- Create: `packages/simulation/simulation/aggregate.py`
+- Create: `packages/simulation/tests/test_aggregate.py`
+- Modify: `packages/simulation/tests/test_result.py`
+- Modify: `packages/simulation/simulation/engine.py` (return type name only)
+
+- [ ] **Step 1: Write failing aggregation test**
+
+Create `packages/simulation/tests/test_aggregate.py`:
+
+```python
+from datetime import datetime
+
+import numpy as np
+from simulation.aggregate import aggregate_percentiles
+from simulation.result import RawSimulationResult
+
+
+def _raw(*, balance_start: np.ndarray) -> RawSimulationResult:
+    num_runs, months = balance_start.shape
+    zeros = np.zeros((num_runs, months), dtype=np.float64)
+    return RawSimulationResult(
+        ran_at=datetime(2026, 1, 1),
+        horizon_months=months,
+        num_runs=num_runs,
+        balance_start=balance_start,
+        withdrawals_essential=zeros,
+        withdrawals_discretionary=zeros,
+        withdrawals_general=zeros,
+        withdrawals_total=balance_start * 0.1,  # distinct from balance for mapping check
+        savings_stock_allocation=zeros,
+        num_runs_insufficient=0,
+    )
+
+
+def test_aggregate_percentiles_reduces_each_array_field_along_runs():
+    # Column 0 values [1, 2, 3]; column 1 [10, 20, 30]
+    balance_start = np.array(
+        [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]], dtype=np.float64
+    )
+    percentiles = [0, 50, 100]
+    raw = _raw(balance_start=balance_start)
+
+    reduced = aggregate_percentiles(raw, percentiles=percentiles)
+
+    assert reduced.balance_start.shape == (len(percentiles), raw.horizon_months)
+    np.testing.assert_allclose(
+        reduced.balance_start,
+        np.percentile(raw.balance_start, percentiles, axis=0),
+    )
+    np.testing.assert_allclose(
+        reduced.withdrawals_total,
+        np.percentile(raw.withdrawals_total, percentiles, axis=0),
+    )
+    assert reduced.percentiles == percentiles
+    assert reduced.num_runs == raw.num_runs
+```
+
+This asserts **our field mapping** (each series reduced the same way), not NumPy in isolation.
+
+- [ ] **Step 2: Run test to verify logical failure**
+
+Run: `uv run pytest packages/simulation/tests/test_aggregate.py -v`
+
+- [ ] **Step 3: Implement result split + aggregate**
+
+In `result.py`:
+
+1. Rename current class to `RawSimulationResult` (same fields; keep `_ARRAY_FIELDS` + `__eq__`).
+2. Add public `SimulationResult` with:
+   - same metadata as raw, plus `percentiles: list[int]`, `start_month: tuple[int, int]`
+   - percentile arrays: `balance_start`, withdrawals_*, `savings_stock_allocation`
+   - composition: `wealth_job`, `wealth_social_security`, `wealth_pension`, `wealth_manual` (1-D)
+   - `_ARRAY_FIELDS` for equality covering all ndarray fields
+3. Set `ENGINE_VERSION = "phase3d"`
+
+In `aggregate.py`:
+
+```python
+from __future__ import annotations
+
+import numpy as np
+from simulation.composition import WealthBySource
+from simulation.result import RawSimulationResult, SimulationResult
+
+_RAW_SERIES = (
+    "balance_start",
+    "withdrawals_essential",
+    "withdrawals_discretionary",
+    "withdrawals_general",
+    "withdrawals_total",
+    "savings_stock_allocation",
+)
+
+
+def aggregate_percentiles(
+    raw: RawSimulationResult, *, percentiles: list[int]
+) -> SimulationResult:
+    """Reduce raw run-major arrays to percentile-major; composition filled later."""
+    reduced = {
+        name: np.percentile(getattr(raw, name), percentiles, axis=0)
+        for name in _RAW_SERIES
+    }
+    months = raw.horizon_months
+    zeros = np.zeros(months, dtype=np.float64)
+    return SimulationResult(
+        ran_at=raw.ran_at,
+        horizon_months=months,
+        num_runs=raw.num_runs,
+        percentiles=list(percentiles),
+        start_month=(0, 0),  # placeholder; build_public_result sets real value
+        balance_start=reduced["balance_start"],
+        withdrawals_essential=reduced["withdrawals_essential"],
+        withdrawals_discretionary=reduced["withdrawals_discretionary"],
+        withdrawals_general=reduced["withdrawals_general"],
+        withdrawals_total=reduced["withdrawals_total"],
+        savings_stock_allocation=reduced["savings_stock_allocation"],
+        wealth_job=zeros,
+        wealth_social_security=zeros.copy(),
+        wealth_pension=zeros.copy(),
+        wealth_manual=zeros.copy(),
+        num_runs_insufficient=raw.num_runs_insufficient,
+    )
+
+
+def build_public_result(
+    raw: RawSimulationResult,
+    *,
+    percentiles: list[int],
+    composition: WealthBySource,
+    start_month: tuple[int, int],
+) -> SimulationResult:
+    result = aggregate_percentiles(raw, percentiles=percentiles)
+    return result.model_copy(
+        update={
+            "start_month": start_month,
+            "wealth_job": composition.job,
+            "wealth_social_security": composition.social_security,
+            "wealth_pension": composition.pension,
+            "wealth_manual": composition.manual,
+        }
+    )
+```
+
+Prefer constructing `SimulationResult` once in `build_public_result` (no placeholder `start_month`) if that keeps types cleaner — either way is fine as long as tests pass.
+
+Update `engine.py` to return `RawSimulationResult`.
+
+Update `test_result.py` to construct public `SimulationResult` with percentile shapes + composition zeros + `percentiles` / `start_month`, **or** move array-equality tests to `RawSimulationResult` and add one public-shape smoke via aggregate tests. Prefer: keep equality tests on `RawSimulationResult`; delete obsolete public-as-raw tests.
+
+- [ ] **Step 4: Fix engine tests + run**
+
+`test_engine.py` indexes `result.withdrawals_general[0, 0]` — still valid on raw. Only change imports if they reference `SimulationResult`.
+
+Run:
+
+```bash
+uv run pytest packages/simulation/tests/test_aggregate.py \
+  packages/simulation/tests/test_result.py \
+  packages/simulation/tests/test_engine.py -v
+```
+
+Expected: PASS for those. `test_run_simulation.py` may still fail until Task 6 — that is OK if you do not run it yet. Prefer running only the listed files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/simulation/simulation/result.py \
+  packages/simulation/simulation/aggregate.py \
+  packages/simulation/simulation/engine.py \
+  packages/simulation/tests/test_aggregate.py \
+  packages/simulation/tests/test_result.py
+git commit -m "$(cat <<'EOF'
+feat(simulation): add percentile aggregation and split raw/public results
+
+EOF
+)"
+```
+
+---
+
+### Task 6: Wire `run_simulation`
+
+**Files:**
+- Modify: `packages/simulation/simulation/stub.py`
+- Modify: `packages/simulation/simulation/__init__.py`
+- Modify: `packages/simulation/tests/test_run_simulation.py`
+
+- [ ] **Step 1: Rewrite failing public-contract tests**
+
+Replace `packages/simulation/tests/test_run_simulation.py` with:
+
+```python
+from datetime import date, datetime
+
+from core.defaults import default_plan
+from core.models import DEFAULT_PERCENTILES, AdvancedConfig
+from core.timeline import Timeline
+from simulation.result import ENGINE_VERSION
+from simulation import run_simulation
+
+
+def test_run_simulation_returns_percentile_major_series():
+    plan = default_plan()
+    percentiles = [10, 50, 90]
+
+    result = run_simulation(
+        plan,
+        percentiles=percentiles,
+        today=date(2026, 1, 1),
+        ran_at=datetime(2026, 1, 1),
+    )
+
+    assert result.engine_version == ENGINE_VERSION
+    assert result.percentiles == percentiles
+    assert result.num_runs == plan.sampling.num_runs
+    assert result.balance_start.shape == (len(percentiles), result.horizon_months)
+    assert result.withdrawals_total.shape == result.balance_start.shape
+    assert result.wealth_job.shape == (result.horizon_months,)
+
+
+def test_run_simulation_uses_plan_advanced_percentiles_when_kwarg_omitted():
+    plan_percentiles = [5, 25, 75, 95]
+    plan = default_plan().model_copy(
+        update={"advanced": AdvancedConfig(percentiles=plan_percentiles)}
+    )
+
+    result = run_simulation(
+        plan,
+        today=date(2026, 1, 1),
+        ran_at=datetime(2026, 1, 1),
+    )
+
+    assert result.percentiles == plan_percentiles
+
+
+def test_run_simulation_kwarg_overrides_plan_percentiles():
+    plan = default_plan()  # defaults to DEFAULT_PERCENTILES
+    override = [1, 99]
+    assert plan.advanced.percentiles == DEFAULT_PERCENTILES
+
+    result = run_simulation(
+        plan,
+        percentiles=override,
+        today=date(2026, 1, 1),
+        ran_at=datetime(2026, 1, 1),
+    )
+
+    assert result.percentiles == sorted(override)
+
+
+def test_run_simulation_start_month_and_horizon_match_timeline():
+    today = date(2026, 6, 15)
+    plan = default_plan()
+    timeline = Timeline(plan, today=today)
+
+    result = run_simulation(
+        plan,
+        today=today,
+        ran_at=datetime(2026, 6, 15),
+    )
+
+    assert result.start_month == (today.year, today.month)
+    assert result.horizon_months == timeline.horizon_months
+```
+
+- [ ] **Step 2: Run tests to verify logical failure**
+
+Run: `uv run pytest packages/simulation/tests/test_run_simulation.py -v`
+
+Expected: shape / attribute failures (still returning raw).
+
+- [ ] **Step 3: Implement wiring**
+
+In `stub.py`:
+
+```python
+from core.models import normalize_percentiles
+from domain import build_monthly_cashflows
+from simulation.aggregate import build_public_result
+from simulation.composition import wealth_by_income_source
+from simulation.engine import simulate_monthly
+from simulation.market_data import build_return_paths, resolve_inflation
+from simulation.preprocess import preprocess
+from simulation.result import SimulationResult
+import numpy as np
+
+
+def run_simulation(
+    plan: Plan,
+    *,
+    percentiles: list[int] | None = None,
+    today: date | None = None,
+    ran_at: datetime | None = None,
+    allow_refresh: bool = False,
+    now: datetime | None = None,
+    fred_api_key: str | None = None,
+    eod_api_key: str | None = None,
+) -> SimulationResult:
+    today = today or date.today()
+    ran_at = ran_at or datetime.now()
+    resolved = normalize_percentiles(
+        percentiles if percentiles is not None else plan.advanced.percentiles
+    )
+
+    processed = preprocess(
+        plan,
+        today=today,
+        allow_refresh=allow_refresh,
+        now=now,
+        fred_api_key=fred_api_key,
+        eod_api_key=eod_api_key,
+    )
+    paths = build_return_paths(plan, months_per_run=processed.months, today=today)
+    raw = simulate_monthly(
+        processed,
+        stocks_return=paths.stocks_log_to_simple(),
+        bonds_return=paths.bonds_log_to_simple(),
+        ran_at=ran_at,
+    )
+
+    cashflows = build_monthly_cashflows(plan, today=today)
+    inflation = resolve_inflation(
+        plan,
+        today=today,
+        allow_refresh=allow_refresh,
+        now=now,
+        api_key=fred_api_key,
+    )
+    composition = wealth_by_income_source(
+        gross_job=np.array([float(v) for v in cashflows.gross_job], dtype=np.float64),
+        gross_social_security=np.array(
+            [float(v) for v in cashflows.gross_social_security], dtype=np.float64
+        ),
+        gross_pension=np.array(
+            [float(v) for v in cashflows.gross_pension], dtype=np.float64
+        ),
+        gross_manual=np.array(
+            [float(v) for v in cashflows.gross_manual], dtype=np.float64
+        ),
+        taxes=np.array(
+            [float(v) for v in cashflows.taxes.stored_total], dtype=np.float64
+        ),
+        monthly_inflation=inflation.monthly,
+        monthly_bond_rate=processed.monthly_planning_bonds,
+    )
+
+    return build_public_result(
+        raw,
+        percentiles=resolved,
+        composition=composition,
+        start_month=(today.year, today.month),
+    )
+```
+
+**Avoid double work if easy:** `preprocess` already builds cashflows and inflation.
+Prefer threading composition inputs out of `preprocess` / `ProcessedPlan` when it is a
+small additive change (e.g. stash `monthly_inflation` on `ProcessedPlan` and pass
+gross/tax arrays already computed). Otherwise the double `build_monthly_cashflows` /
+`resolve_inflation` call above is acceptable for 3d — same deterministic inputs; cost is
+dwarfed by Monte Carlo. Do **not** invent a large refactor mid-task.
+
+Ensure `__init__.py` still exports `SimulationResult` (public) and does **not** export `RawSimulationResult`.
+
+- [ ] **Step 4: Run simulation + web smoke**
+
+Run:
+
+```bash
+uv run pytest packages/simulation/tests/test_run_simulation.py \
+  packages/web/tests/test_app.py -v
+```
+
+Expected: PASS (`balance_start[0][0]` stub still works).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/simulation/simulation/stub.py \
+  packages/simulation/simulation/__init__.py \
+  packages/simulation/simulation/preprocess.py \
+  packages/simulation/tests/test_run_simulation.py
+git commit -m "$(cat <<'EOF'
+feat(simulation): return percentile results and wealth composition from run_simulation
+
+EOF
+)"
+```
+
+---
+
+### Task 7: Docs + rebuild index
+
+**Files:**
+- Modify: `packages/simulation/OVERVIEW.md`
+- Modify: `packages/simulation/README.md`
+- Modify: `docs/superpowers/plans/2026-06-12-rebuild-index.md`
+
+- [ ] **Step 1: Update OVERVIEW.md**
+
+In the feature parity table:
+
+- Set “Percentile aggregation …” to **Ported (Phase 3d)** → `simulation/aggregate.py`
+- Add row: wealth composition (tax-prorated NPV by source) → **Ported (Phase 3d)** → `simulation/composition.py`
+- List deferred series explicitly (withdrawal rate, total-portfolio stock allocation, spending-tilt series, ending-balance scalars)
+- Remove the “percentiles accepted but unused” paragraph; note public result is percentile-reduced and raw is internal
+
+- [ ] **Step 2: Update README.md**
+
+Replace “raw results / Phase 3d” wording with: public `SimulationResult` is percentile-major; `RawSimulationResult` is engine-internal; composition bands support stacked total-portfolio charts in Phase 4.
+
+- [ ] **Step 3: Update rebuild index**
+
+- Active phase → Phase 4 (or keep 3d complete and set next action to write Phase 4 plan — match prior phase-completion pattern)
+- Phase 3d exit criteria checkboxes aligned to spec §13 (all checked when done)
+- Completed plans table: add Phase 3d plan file
+- Active plan: Phase 4 plan *(to write)*
+
+Phase 3d exit criteria text:
+
+```markdown
+- [x] Public `SimulationResult` is percentile-major (balance, withdrawals, savings allocation)
+- [x] Aggregation via `numpy.percentile` along runs
+- [x] `plan.advanced.percentiles` default `[5, 50, 95]`; kwarg overrides
+- [x] Wealth composition (job/SS/pension/manual) tax-prorated NPV bands
+- [x] `start_month` + horizon match `Timeline` (items 30–31)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/simulation/OVERVIEW.md packages/simulation/README.md \
+  docs/superpowers/plans/2026-06-12-rebuild-index.md
+git commit -m "$(cat <<'EOF'
+docs(simulation): record Phase 3d results data layer parity
+
+EOF
+)"
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Run `make`**
+
+Run from repo root: `make`
+
+Expected: lint + tests pass.
+
+- [ ] **Step 2: Fix any failures**
+
+If web or core tests fail on `Plan` construction missing `advanced`, they should not — `default_factory` applies. Fix real breakages only.
+
+- [ ] **Step 3: Final commit only if Step 2 produced fixes**
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+| ---------------- | ---- |
+| `plan.advanced.percentiles` + default `[5, 50, 95]` | 1 |
+| `normalize_percentiles` / validation | 1 |
+| Shared bond NPV including current | 2 |
+| Tax proration (signed taxes) | 3 |
+| Wealth composition by source | 4 |
+| `RawSimulationResult` private / public percentile result | 5 |
+| `numpy.percentile` aggregation | 5 |
+| `run_simulation` wiring + kwarg override | 6 |
+| `start_month` + horizon vs `Timeline` | 6 |
+| OVERVIEW / README / rebuild-index | 7 |
+| `make` passes | 8 |
+| No chart UI | (out of scope — no task) |
+| Deferred tpaw series | documented in 7 |
+
+---
+
+## Placeholder / consistency notes
+
+- Public composition field names: `wealth_job`, `wealth_social_security`, `wealth_pension`, `wealth_manual` (match spec).
+- `WealthBySource` attributes: `job`, `social_security`, `pension`, `manual`.
+- Engine returns `RawSimulationResult`; package export is public `SimulationResult` only.
+- Do not re-export `RawSimulationResult` from `simulation.__init__`.

--- a/docs/superpowers/plans/2026-06-12-rebuild-index.md
+++ b/docs/superpowers/plans/2026-06-12-rebuild-index.md
@@ -34,9 +34,9 @@
 
 | Field             | Value                                                      |
 | ----------------- | ---------------------------------------------------------- |
-| **Current phase** | Phase 3d — plan                                            |
-| **Active plan**   | `2026-06-12-phase-3d-simulation-results.md` *(to write)*  |
-| **Next action**   | Write Phase 3d plan before coding                           |
+| **Current phase** | Phase 4 — plan                                             |
+| **Active plan**   | `2026-06-12-phase-4-web-ui.md` *(to write)*               |
+| **Next action**   | Write Phase 4 plan before coding                           |
 
 
 When a phase completes: set its plan header to `status: complete`, update this table, and write the next phase plan before coding.
@@ -325,19 +325,21 @@ tpaw pulls daily EOD prices from [EODHD](https://eodhd.com/) for preset math (`G
 
 ### Phase 3d — Simulation: results data layer
 
-**Plan file:** `2026-06-12-phase-3d-simulation-results.md` *(to write)*
+**Plan file:** `2026-06-12-phase-3d-simulation-results.md`
 
-**Delivers:** `SimulationResult` structure covering all tpaw major chart data series; configurable percentiles; dated plan starts from today.
+**Delivers:** Public percentile-major `SimulationResult` (balance, withdrawals, savings allocation) plus tax-prorated wealth composition bands; configurable percentiles via `plan.advanced.percentiles`; `start_month` from today.
 
-**References:** tpaw `wire_simulate_api.proto`; design spec §6 items 5, 24, 30–31.
+**References:** tpaw `wire_simulate_api.proto`; design spec §6 items 5, 24, 30–31; `docs/superpowers/specs/2026-07-10-phase-3d-simulation-results-design.md`.
 
 **Entry criteria:** Phase 3c complete.
 
 **Exit criteria:**
 
-- [ ] Result types match chart requirements (balance, spending, withdrawals, allocation, …)
-- [ ] User-configurable percentile list
-- [ ] Per-person end age respected; simulation starts from today
+- [x] Public `SimulationResult` is percentile-major (balance, withdrawals, savings allocation)
+- [x] Aggregation via `numpy.percentile` along runs
+- [x] `plan.advanced.percentiles` default `[5, 50, 95]`; kwarg overrides
+- [x] Wealth composition (job/SS/pension/manual) tax-prorated NPV bands
+- [x] `start_month` + horizon match `Timeline` (items 30–31)
 
 **After Phase 3d:** Agent workspace may shrink to LifeFinances-only for most work.
 
@@ -437,10 +439,11 @@ tpaw pulls daily EOD prices from [EODHD](https://eodhd.com/) for preset math (`G
 | Phase 3a | `2026-06-12-phase-3a-simulation-market-data.md` | complete |
 | Phase 3c-1 | `2026-06-12-phase-3c-1-simulation-market-feeds.md` | complete |
 | Phase 3c-2 | `2026-06-12-phase-3c-2-simulation-planning-returns-presets.md` | complete |
+| Phase 3d | `2026-06-12-phase-3d-simulation-results.md` | complete |
 
 
 ---
 
 ## Next step
 
-Write **Phase 3d plan** before coding.
+Write **Phase 4 plan** before coding.

--- a/docs/superpowers/specs/2026-07-10-phase-3d-simulation-results-design.md
+++ b/docs/superpowers/specs/2026-07-10-phase-3d-simulation-results-design.md
@@ -1,0 +1,325 @@
+# Phase 3d — Simulation: Results Data Layer Design
+
+**Date:** 2026-07-10
+**Status:** Approved
+**Parent:** [2026-06-12-life-finances-rebuild-design.md](./2026-06-12-life-finances-rebuild-design.md)
+**Builds on:** [2026-06-29-phase-3b-simulation-tpaw-withdrawals-design.md](./2026-06-29-phase-3b-simulation-tpaw-withdrawals-design.md),
+[2026-07-05-phase-3c-2-simulation-planning-returns-presets-design.md](./2026-07-05-phase-3c-2-simulation-planning-returns-presets-design.md)
+**Phase plan:** `docs/superpowers/plans/2026-06-12-phase-3d-simulation-results.md` *(to write after spec approval)*
+**Commit:** Deferred until implementation (spec lands uncommitted / with the implementation PR).
+
+---
+
+## 1. Goal & scope
+
+Turn the Phase 3b raw per-run engine output into a **chart-ready public result
+contract**: percentile-reduced time series plus a deterministic **total-portfolio
+wealth composition** (savings vs income sources) for stacked visualization.
+
+Phase 4 renders charts; this phase owns only the simulation/core data layer.
+
+### In scope
+
+- Split today’s `SimulationResult` into a private raw type and a public
+  percentile-reduced `SimulationResult`.
+- Percentile aggregation over the run axis via `numpy.percentile`.
+- `plan.advanced.percentiles` (default `[5, 50, 95]`) with kwarg override on
+  `run_simulation`.
+- Deterministic wealth-composition series: savings + tax-prorated remaining-income
+  NPV by source (`job` / `social_security` / `pension` / `manual`).
+- `start_month` metadata on the public result for Phase 4 x-axis labeling.
+- Document/test that horizon already starts from `today` and respects per-person
+  end age (`Timeline` — parity items 30–31).
+- Update `packages/simulation/OVERVIEW.md` (+ brief README note).
+
+### Out of scope
+
+- Web chart rendering / HTMX chart payloads → Phase 4.
+- Deferred tpaw major series: withdrawal rate from savings, total-portfolio
+  **stock** allocation, spending-tilt series, ending-balance percentile scalars.
+- tpaw NPV-for-balance-sheet blob.
+- Per-run bootstrapped inflation ([#186](https://github.com/chriskelly/LifeFinances/issues/186)).
+- Advanced-options editor UI → Phase 4.
+
+---
+
+## 2. Decisions captured from brainstorming
+
+| # | Decision | Rationale |
+| - | -------- | --------- |
+| 1 | **Simulation package only** | Charts stay Phase 4; 3d ships the data contract. |
+| 2 | **Public result = percentile-reduced; raw is private** | Matches tpaw’s wire shape; keeps web memory down; engine tests keep raw arrays. |
+| 3 | **Percentiles on `plan.advanced`** | Rarely adjusted; doesn’t belong under sampling (Monte Carlo) or a display-only nest. |
+| 4 | **Default `[5, 50, 95]`** | tpaw UI default (`low` / `mid` / `high`). |
+| 5 | **Percentile-reduce existing engine series only** | Defer withdrawal-rate / total-portfolio stock allocation / spending-tilt / ending-balance scalars. |
+| 6 | **Add wealth composition (wealth view)** | Stacked chart: savings + NPV of remaining income by domain source. |
+| 7 | **Income slices = cashflow aggregates** | `job` / `social_security` / `pension` / `manual`. |
+| 8 | **Tax proration across sources** | `net_s = gross_s + taxes.stored_total × share` (taxes are non-positive); no separate tax band. |
+| 9 | **Post-process aggregator (Approach 1)** | `simulate → raw → aggregate + composition → public`; composition stays out of the Monte Carlo loop. |
+| 10 | **`numpy.percentile` (not tpaw pick-from-sorted)** | Simpler; speed is a wash at our sizes. Accepts linear interpolation vs tpaw’s order-statistic pick. |
+| 11 | **Do not commit the spec until implementation** | Spec may land with the implementation PR. |
+
+---
+
+## 3. Architecture
+
+```
+Plan (+ today)
+  → preprocess (cashflows, inflation, planning returns, risk/Merton, NPV)
+  → simulate_monthly → RawSimulationResult   # num_runs × months; private
+  → aggregate_percentiles(raw, percentiles)
+  → attach wealth composition (deterministic)
+  → SimulationResult                         # public; percentile × months
+```
+
+| Piece | Role |
+| ----- | ---- |
+| `engine.simulate_monthly` | Emits `RawSimulationResult` (today’s array fields, renamed type). |
+| `result.py` | `RawSimulationResult` (private) + public `SimulationResult`. |
+| `aggregate.py` (new) | Percentile reduction over the run axis. |
+| Composition helper (new module or preprocess) | Tax-prorated per-source remaining-income NPV. |
+| `core.models.AdvancedConfig` | `percentiles: list[int]`; nested on `Plan.advanced`. |
+| `run_simulation` | Resolve percentiles (kwarg → plan → default); return public result. |
+
+**Package dependency direction unchanged:** `simulation` → `domain`, `core`.
+
+---
+
+## 4. Plan config — `AdvancedConfig`
+
+```python
+DEFAULT_PERCENTILES = [5, 50, 95]
+
+class AdvancedConfig(BaseModel):
+    percentiles: list[int] = Field(default_factory=lambda: list(DEFAULT_PERCENTILES))
+
+    @field_validator("percentiles")
+    @classmethod
+    def _validate_percentiles(cls, value: list[int]) -> list[int]:
+        if not value:
+            raise ValueError("percentiles must be non-empty")
+        if any(p < 0 or p > 100 for p in value):
+            raise ValueError("each percentile must be in 0..100")
+        return sorted(value)
+
+class Plan(BaseModel):
+    ...
+    advanced: AdvancedConfig = Field(default_factory=AdvancedConfig)
+```
+
+`advanced` holds options that are rarely adjusted and do not group cleanly elsewhere.
+Percentiles are the first field; later phases may add more.
+
+**Resolution in `run_simulation`:**
+
+1. If `percentiles` kwarg is not `None`, use it (after the same validation rules).
+2. Else use `plan.advanced.percentiles`.
+
+---
+
+## 5. Result types
+
+### 5.1 `RawSimulationResult` (private)
+
+Same fields the engine emits today — shape `(num_runs, months)`:
+
+- `balance_start`
+- `withdrawals_essential` / `withdrawals_discretionary` / `withdrawals_general` /
+  `withdrawals_total`
+- `savings_stock_allocation`
+- plus `ran_at`, `horizon_months`, `num_runs`, `num_runs_insufficient`,
+  `engine_version`
+
+Not part of the public `simulation` package API (may live in `result.py` but not
+re-exported from `simulation.__init__` as the primary result type).
+
+### 5.2 Public `SimulationResult`
+
+**Percentile series** — shape `(num_percentiles, months)`, float64, percentile-major
+(row `i` corresponds to `percentiles[i]`):
+
+| Field | Source |
+| ----- | ------ |
+| `balance_start` | raw → percentile |
+| `withdrawals_essential` | raw → percentile |
+| `withdrawals_discretionary` | raw → percentile |
+| `withdrawals_general` | raw → percentile |
+| `withdrawals_total` | raw → percentile |
+| `savings_stock_allocation` | raw → percentile |
+
+**Wealth composition** (stacked total-portfolio chart):
+
+| Field | Shape | Nature |
+| ----- | ----- | ------ |
+| `wealth_job` | `(months,)` | deterministic remaining-income NPV (tax-prorated) |
+| `wealth_social_security` | `(months,)` | deterministic |
+| `wealth_pension` | `(months,)` | deterministic |
+| `wealth_manual` | `(months,)` | deterministic |
+
+Savings band for charts is `balance_start[percentile_index, :]` — no duplicate
+`wealth_savings` array.
+
+At percentile `p` and month `m`:
+
+```
+balance_start[p, m]
+  + wealth_job[m] + wealth_social_security[m]
+  + wealth_pension[m] + wealth_manual[m]
+```
+
+≈ engine total wealth for that savings path
+(`balance + npv_income_without_current + income`).
+
+**Metadata:**
+
+- `ran_at`, `horizon_months`, `num_runs`, `num_runs_insufficient`
+- `percentiles: list[int]` — resolved list used for this run
+- `start_month: tuple[int, int]` — `(year, month)` of month index 0 (`today`)
+- `engine_version`
+
+---
+
+## 6. Percentile aggregation
+
+Use NumPy’s stock percentile along the run axis (default linear interpolation):
+
+```python
+np.percentile(raw_array, percentiles, axis=0)
+# → shape (num_percentiles, months)
+```
+
+Apply independently to each raw array field listed in §5.2.
+
+**Note:** This differs from tpaw’s `pickPercentilesFromSorted` (order-statistic index
+pick). At typical `num_runs` the visual difference is negligible; we prefer the simpler
+API over bit-level chart parity.
+
+---
+
+## 7. Wealth composition (tax-prorated NPV)
+
+**Display-only** — does not change withdrawal / allocation engine math.
+
+### 7.1 Tax proration (per month)
+
+Sources `s ∈ {job, social_security, pension, manual}`.
+
+Domain stores taxes as **non-positive** amounts on `TaxBreakdown.stored_total`
+(`net_cashflow[m] = total_gross[m] + taxes.stored_total[m]`). Proration must use
+that same signed total:
+
+When `total_gross[m] > 0`:
+
+```
+share_s = gross_s[m] / total_gross[m]
+net_s[m] = gross_s[m] + taxes.stored_total[m] * share_s
+```
+
+When `total_gross[m] == 0`: all `net_s[m] = 0` (any residual taxes that month are
+omitted from composition; the engine still uses `net_cashflow`).
+
+Invariant when `total_gross[m] > 0`: `Σ net_s[m] == net_cashflow[m]` (float tolerance).
+
+### 7.2 Real dollars + NPV
+
+Deflate each `net_s` with the same inflation deflator preprocess uses for income.
+Backward NPV at the planning **bond** rate, same recurrence as combined income NPV.
+
+At month `m`, `wealth_s[m]` is the NPV of `net_s[m:]` **including** the current month,
+so:
+
+```
+Σ wealth_s[m] == npv_income_without_current[m] + income_real[m]
+```
+
+(within float tolerance), when composition and preprocess share the same discount path
+and the same net income total.
+
+### 7.3 Determinism
+
+Composition arrays do not vary by run or percentile. Phase 4 stacks percentile
+`balance_start` under the four fixed income bands.
+
+---
+
+## 8. Horizon (parity items 30–31)
+
+Already implemented via `core.timeline.Timeline`:
+
+- Month 0 = current calendar month of injected/`date.today()` `today`.
+- Horizon ends at the later present person’s end date (`birth + max_age_years`).
+
+Phase 3d does **not** change timeline logic. It:
+
+- Sets `start_month` from the same `today` used for the run.
+- Adds a regression test that public `horizon_months` / `start_month` match `Timeline`.
+
+---
+
+## 9. Testing strategy
+
+TDD throughout; confirm logical (not structural) red before implementing.
+
+1. **Percentile aggregation** — known raw column; output matches `np.percentile(..., axis=0)`
+   and shape `(P, M)`.
+2. **Tax proration** — known gross/tax month → nets sum to `net_cashflow`; zero-gross → zeros.
+3. **Composition NPV** — short horizon, constant bond rate; `Σ wealth_s` matches combined
+   income wealth; savings + income wealth matches hand total at month 0.
+4. **`run_simulation` public contract** — percentile shapes (not `num_runs × months`);
+   `result.percentiles` echoes resolved list; kwarg overrides `plan.advanced.percentiles`.
+5. **Horizon** — injected `today` + distinct end ages → `horizon_months` / `start_month`
+   match `Timeline`.
+6. **Plan validation** — empty / out-of-range percentiles rejected.
+
+No chart-rendering or HTMX tests in this phase.
+
+---
+
+## 10. Error handling
+
+- Invalid percentiles on `Plan` fail Pydantic validation at save/load.
+- Kwarg percentiles validated with the same rules before aggregation.
+- Aggregation requires `num_runs ≥ 1` (already guaranteed by `SamplingConfig`).
+- Composition introduces no new failure modes beyond existing preprocess / cashflow errors.
+
+---
+
+## 11. Documentation & index updates
+
+- `packages/simulation/OVERVIEW.md` — mark percentile aggregation + wealth composition
+  as ported in 3d; list deferred tpaw series explicitly.
+- `packages/simulation/README.md` — short note: public result is percentile-reduced;
+  raw arrays are an internal engine artifact.
+- `docs/superpowers/plans/2026-06-12-rebuild-index.md` — Phase 3d exit criteria aligned
+  to this spec (public percentile series + composition + `advanced.percentiles` +
+  horizon verification).
+
+---
+
+## 12. Explicitly deferred (not 3d)
+
+| Item | Destination |
+| ---- | ----------- |
+| Chart UI / results panel series wiring | Phase 4 |
+| Withdrawal rate from savings | Later / if Phase 4 needs it |
+| Total-portfolio stock allocation series | Later |
+| Spending-tilt result series | Later (tilt already drives engine) |
+| Ending-balance percentile scalars | Later |
+| NPV balance-sheet approx blob | Later / skip unless needed |
+| Bootstrapped inflation paths | [#186](https://github.com/chriskelly/LifeFinances/issues/186) |
+| Advanced percentiles editor UI | Phase 4 |
+
+---
+
+## 13. Exit criteria
+
+- [ ] `RawSimulationResult` is private; `run_simulation` returns public
+      `SimulationResult` with percentile-major series for balance, withdrawals, and
+      savings stock allocation.
+- [ ] Aggregation uses `numpy.percentile` along the run axis (§6).
+- [ ] `plan.advanced.percentiles` defaults to `[5, 50, 95]`; kwarg overrides.
+- [ ] Wealth composition fields present and reconcile with combined income NPV under
+      tax proration (§7).
+- [ ] `start_month` + horizon tests document dated start / per-person end age.
+- [ ] `OVERVIEW.md` / README / rebuild-index updated.
+- [ ] `make` passes.

--- a/packages/core/core/models.py
+++ b/packages/core/core/models.py
@@ -16,6 +16,7 @@ DEFAULT_BLOCK_SIZE_MONTHS = 60  # tpaw blockSize.inMonths = 12 * 5
 DEFAULT_NUM_RUNS = 500  # tpaw numOfSimulationForMonteCarloSampling
 DEFAULT_STAGGER_RUN_STARTS = True  # tpaw staggerRunStarts
 DEFAULT_SAMPLING_SEED = 1_234_567  # LifeFinances default for reproducibility
+DEFAULT_PERCENTILES = [5, 50, 95]
 
 DEFAULT_RISK_TOLERANCE_AT_20 = Decimal(12)  # tpaw default test plan "Moderate"
 DEFAULT_DELTA_AT_MAX_AGE = Decimal(0)
@@ -58,6 +59,23 @@ class AppSettings(BaseModel):
             stripped = value.strip()
             return stripped or None
         return value
+
+
+def normalize_percentiles(value: list[int]) -> list[int]:
+    if not value:
+        raise ValueError("percentiles must be non-empty")
+    if any(p < 0 or p > 100 for p in value):
+        raise ValueError("each percentile must be in 0..100")
+    return sorted(value)
+
+
+class AdvancedConfig(BaseModel):
+    percentiles: list[int] = Field(default_factory=lambda: list(DEFAULT_PERCENTILES))
+
+    @field_validator("percentiles")
+    @classmethod
+    def _normalize_percentiles(cls, value: list[int]) -> list[int]:
+        return normalize_percentiles(value)
 
 
 class SamplingConfig(BaseModel):
@@ -191,6 +209,7 @@ class Plan(BaseModel):
     planning_returns: PlanningReturnsConfig = Field(
         default_factory=PlanningReturnsConfig
     )
+    advanced: AdvancedConfig = Field(default_factory=AdvancedConfig)
     extra_essential_spending: list[TimedStream] = Field(default_factory=list)
     extra_discretionary_spending: list[TimedStream] = Field(default_factory=list)
     # Interpreted as already-real (today's dollars) by the simulation engine —

--- a/packages/core/tests/test_advanced_config.py
+++ b/packages/core/tests/test_advanced_config.py
@@ -1,0 +1,32 @@
+import pytest
+from core.models import (
+    DEFAULT_PERCENTILES,
+    AdvancedConfig,
+    normalize_percentiles,
+)
+
+
+def test_normalize_percentiles_sorts_ascending():
+    unsorted = [90, 5, 50]
+    expected = sorted(unsorted)
+
+    assert normalize_percentiles(unsorted) == expected
+
+
+def test_normalize_percentiles_rejects_empty():
+    with pytest.raises(ValueError, match="non-empty"):
+        normalize_percentiles([])
+
+
+def test_normalize_percentiles_rejects_out_of_range():
+    with pytest.raises(ValueError, match="0..100"):
+        normalize_percentiles([50, 101])
+
+
+def test_advanced_config_uses_normalize_percentiles():
+    # Our validator must apply the same normalization (sort), not leave input order.
+    unsorted = [95, 5, 50]
+    config = AdvancedConfig(percentiles=unsorted)
+
+    assert config.percentiles == normalize_percentiles(unsorted)
+    assert DEFAULT_PERCENTILES == [5, 50, 95]  # pinned: tpaw UI low/mid/high

--- a/packages/simulation/OVERVIEW.md
+++ b/packages/simulation/OVERVIEW.md
@@ -15,18 +15,26 @@ numerical correctness without a runnable TPAW binary to diff against.
 | Merton's formula (stock allocation + spending tilt, equity-premium/variance clamps, ∞-RRA case) | Ported (Phase 3b) | `simulation/mertons.py` |
 | Backward NPV precompute pass + `cumulative_1_plus_g_over_1_plus_r` amortization | Ported (Phase 3b) | `simulation/npv.py`, `simulation/preprocess.py` |
 | Vectorized forward monthly loop (wealth, pool carve, expected-run elasticity, contributions/withdrawals, allocation, rebalancing) | Ported (Phase 3b) | `simulation/engine.py` |
-| Raw per-run result arrays | Ported (Phase 3b) | `simulation/result.py` |
-| Percentile aggregation (10th/50th/90th, etc. reduction over raw arrays) | Deferred | Phase 3d |
+| Raw per-run result arrays (engine-internal) | Ported (Phase 3b) | `simulation/result.py` (`RawSimulationResult`) |
+| Percentile aggregation (10th/50th/90th, etc. reduction over raw arrays) | Ported (Phase 3d) | `simulation/aggregate.py` |
+| Wealth composition (tax-prorated NPV by income source: job / SS / pension / manual) | Ported (Phase 3d) | `simulation/composition.py` |
 | Planning-returns presets (live CAPE/EOD-derived expected returns, empirical variance refinement) | Ported (Phase 3c-2) | `simulation/market_data/presets.py`, `simulation/market_data/presets_data.py` |
 | S&P + Treasury 20-yr TIPS market feeds (cache + vendored fallback) | Ported (Phase 3c-1) | `simulation/market_data/` |
 | Bootstrapped/stochastic inflation (3b uses a single resolved scalar inflation rate for the whole horizon) | Deferred | Issue #186 |
 | Spending ceiling/floor constraints | Removed from scope | Not planned — this rebuild's product scope removed ceiling/floor |
 | Detailed tax-bucket modeling interactions with withdrawals (traditional vs. Roth vs. taxable sequencing) | Deferred | Later phase, unscheduled |
+| Withdrawal rate from savings | Deferred | Later / if Phase 4 needs it |
+| Total-portfolio stock allocation series | Deferred | Later |
+| Spending-tilt result series | Deferred | Later (tilt already drives engine) |
+| Ending-balance percentile scalars | Deferred | Later |
+| NPV balance-sheet approx blob | Deferred | Later / skip unless needed |
 
-`run_simulation`'s `percentiles: list[int] | None` parameter (see
-`simulation/stub.py`) is already accepted at the call site so downstream API
-shape doesn't need to change again in Phase 3d, but the value is currently
-unused (`_ = percentiles  # reserved for Phase 3d aggregation`).
+`run_simulation` returns a public, percentile-major `SimulationResult` (balance,
+withdrawals, savings stock allocation, plus wealth-composition bands). The engine
+still emits private `RawSimulationResult` (`num_runs × months`); aggregation
+happens in `aggregate.py` via `numpy.percentile` along the run axis. Percentiles
+default from `plan.advanced.percentiles` (`[5, 50, 95]`); the `percentiles`
+kwarg overrides. Chart UI wiring is Phase 4.
 
 ## Numerical parity caveat
 

--- a/packages/simulation/README.md
+++ b/packages/simulation/README.md
@@ -21,9 +21,13 @@ preprocess(plan)                            # NEW
         ▼
 build_return_paths(plan, months)          # Phase 3a (per-run monthly returns)
         ▼
-simulate_monthly(processed, paths)          # NEW vectorized forward loop (engine.py)
+simulate_monthly(processed, paths)          # vectorized forward loop (engine.py)
         ▼
-SimulationResult  (raw per-run arrays)      # expanded result.py
+RawSimulationResult  (engine-internal)      # per-run arrays in result.py
+        ▼
+aggregate + wealth composition            # aggregate.py, composition.py
+        ▼
+SimulationResult  (percentile-major)      # public return from run_simulation
 ```
 
 ## Stage by stage
@@ -134,12 +138,14 @@ vectorized across all simulated runs at once, which is what keeps the whole
 simulation fast (on the order of tens of milliseconds for hundreds of runs over
 multi-decade horizons).
 
-**Raw results.** The engine does not aggregate its output into percentiles or
-charts — that's Phase 3d's job. Instead it returns a `SimulationResult` holding
-the raw per-run, per-month arrays (starting balances, and the essential /
-discretionary / general / total withdrawals, plus the resulting stock
-allocation and a count of runs that ran out of money), so downstream code can
-choose how to summarize them.
+**Public results.** `run_simulation` returns a percentile-major `SimulationResult`:
+each chart series is reduced along the run axis (default percentiles from
+`plan.advanced.percentiles`, overridable via kwarg). The forward loop still
+emits a private `RawSimulationResult` (`num_runs × months`) internally; callers
+should treat raw arrays as an engine artifact, not the public API. Wealth
+composition bands (job, Social Security, pension, manual income — tax-prorated
+remaining NPV at each month) are attached for stacked total-portfolio charts in
+Phase 4.
 
 ## Merton's formula
 

--- a/packages/simulation/simulation/aggregate.py
+++ b/packages/simulation/simulation/aggregate.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import numpy as np
+
+from simulation.composition import WealthBySource
+from simulation.result import RawSimulationResult, SimulationResult
+
+_RAW_SERIES = (
+    "balance_start",
+    "withdrawals_essential",
+    "withdrawals_discretionary",
+    "withdrawals_general",
+    "withdrawals_total",
+    "savings_stock_allocation",
+)
+
+
+def aggregate_percentiles(
+    raw: RawSimulationResult, *, percentiles: list[int]
+) -> SimulationResult:
+    """Reduce raw run-major arrays to percentile-major; composition filled later."""
+    reduced = {
+        name: np.percentile(getattr(raw, name), percentiles, axis=0)
+        for name in _RAW_SERIES
+    }
+    months = raw.horizon_months
+    zeros = np.zeros(months, dtype=np.float64)
+    return SimulationResult(
+        ran_at=raw.ran_at,
+        horizon_months=months,
+        num_runs=raw.num_runs,
+        percentiles=list(percentiles),
+        start_month=(0, 0),  # placeholder; build_public_result sets real value
+        balance_start=reduced["balance_start"],
+        withdrawals_essential=reduced["withdrawals_essential"],
+        withdrawals_discretionary=reduced["withdrawals_discretionary"],
+        withdrawals_general=reduced["withdrawals_general"],
+        withdrawals_total=reduced["withdrawals_total"],
+        savings_stock_allocation=reduced["savings_stock_allocation"],
+        wealth_job=zeros,
+        wealth_social_security=zeros.copy(),
+        wealth_pension=zeros.copy(),
+        wealth_manual=zeros.copy(),
+        num_runs_insufficient=raw.num_runs_insufficient,
+    )
+
+
+def build_public_result(
+    raw: RawSimulationResult,
+    *,
+    percentiles: list[int],
+    composition: WealthBySource,
+    start_month: tuple[int, int],
+) -> SimulationResult:
+    result = aggregate_percentiles(raw, percentiles=percentiles)
+    return result.model_copy(
+        update={
+            "start_month": start_month,
+            "wealth_job": composition.job,
+            "wealth_social_security": composition.social_security,
+            "wealth_pension": composition.pension,
+            "wealth_manual": composition.manual,
+        }
+    )

--- a/packages/simulation/simulation/aggregate.py
+++ b/packages/simulation/simulation/aggregate.py
@@ -3,46 +3,16 @@ from __future__ import annotations
 import numpy as np
 
 from simulation.composition import WealthBySource
-from simulation.result import RawSimulationResult, SimulationResult
-
-_RAW_SERIES = (
-    "balance_start",
-    "withdrawals_essential",
-    "withdrawals_discretionary",
-    "withdrawals_general",
-    "withdrawals_total",
-    "savings_stock_allocation",
-)
+from simulation.result import RAW_ARRAY_FIELDS, RawSimulationResult, SimulationResult
 
 
-def aggregate_percentiles(
+def _percentile_arrays(
     raw: RawSimulationResult, *, percentiles: list[int]
-) -> SimulationResult:
-    """Reduce raw run-major arrays to percentile-major; composition filled later."""
-    reduced = {
+) -> dict[str, np.ndarray]:
+    return {
         name: np.percentile(getattr(raw, name), percentiles, axis=0)
-        for name in _RAW_SERIES
+        for name in RAW_ARRAY_FIELDS
     }
-    months = raw.horizon_months
-    zeros = np.zeros(months, dtype=np.float64)
-    return SimulationResult(
-        ran_at=raw.ran_at,
-        horizon_months=months,
-        num_runs=raw.num_runs,
-        percentiles=list(percentiles),
-        start_month=(0, 0),  # placeholder; build_public_result sets real value
-        balance_start=reduced["balance_start"],
-        withdrawals_essential=reduced["withdrawals_essential"],
-        withdrawals_discretionary=reduced["withdrawals_discretionary"],
-        withdrawals_general=reduced["withdrawals_general"],
-        withdrawals_total=reduced["withdrawals_total"],
-        savings_stock_allocation=reduced["savings_stock_allocation"],
-        wealth_job=zeros,
-        wealth_social_security=zeros.copy(),
-        wealth_pension=zeros.copy(),
-        wealth_manual=zeros.copy(),
-        num_runs_insufficient=raw.num_runs_insufficient,
-    )
 
 
 def build_public_result(
@@ -52,13 +22,22 @@ def build_public_result(
     composition: WealthBySource,
     start_month: tuple[int, int],
 ) -> SimulationResult:
-    result = aggregate_percentiles(raw, percentiles=percentiles)
-    return result.model_copy(
-        update={
-            "start_month": start_month,
-            "wealth_job": composition.job,
-            "wealth_social_security": composition.social_security,
-            "wealth_pension": composition.pension,
-            "wealth_manual": composition.manual,
-        }
+    reduced = _percentile_arrays(raw, percentiles=percentiles)
+    return SimulationResult(
+        ran_at=raw.ran_at,
+        horizon_months=raw.horizon_months,
+        num_runs=raw.num_runs,
+        percentiles=list(percentiles),
+        start_month=start_month,
+        balance_start=reduced["balance_start"],
+        withdrawals_essential=reduced["withdrawals_essential"],
+        withdrawals_discretionary=reduced["withdrawals_discretionary"],
+        withdrawals_general=reduced["withdrawals_general"],
+        withdrawals_total=reduced["withdrawals_total"],
+        savings_stock_allocation=reduced["savings_stock_allocation"],
+        wealth_job=composition.job,
+        wealth_social_security=composition.social_security,
+        wealth_pension=composition.pension,
+        wealth_manual=composition.manual,
+        num_runs_insufficient=raw.num_runs_insufficient,
     )

--- a/packages/simulation/simulation/composition.py
+++ b/packages/simulation/simulation/composition.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
+
+from simulation.npv import backward_npv_including_current
 
 _SOURCE_KEYS = ("job", "social_security", "pension", "manual")
 
@@ -30,3 +34,45 @@ def prorate_net_income_by_source(
         net[positive] = gross[key][positive] + taxes[positive] * share[positive]
         nets[key] = net
     return nets
+
+
+@dataclass(frozen=True)
+class WealthBySource:
+    job: np.ndarray
+    social_security: np.ndarray
+    pension: np.ndarray
+    manual: np.ndarray
+
+
+def wealth_by_income_source(
+    *,
+    gross_job: np.ndarray,
+    gross_social_security: np.ndarray,
+    gross_pension: np.ndarray,
+    gross_manual: np.ndarray,
+    taxes: np.ndarray,
+    monthly_inflation: float,
+    monthly_bond_rate: float,
+) -> WealthBySource:
+    nets = prorate_net_income_by_source(
+        gross_job=gross_job,
+        gross_social_security=gross_social_security,
+        gross_pension=gross_pension,
+        gross_manual=gross_manual,
+        taxes=taxes,
+    )
+    months = gross_job.shape[0]
+    deflator = (1.0 + monthly_inflation) ** np.arange(months, dtype=np.float64)
+    one_over = 1.0 / (1.0 + monthly_bond_rate)
+    bands = {
+        key: backward_npv_including_current(
+            nets[key] / deflator, one_over_1_plus_r=one_over
+        )
+        for key in _SOURCE_KEYS
+    }
+    return WealthBySource(
+        job=bands["job"],
+        social_security=bands["social_security"],
+        pension=bands["pension"],
+        manual=bands["manual"],
+    )

--- a/packages/simulation/simulation/composition.py
+++ b/packages/simulation/simulation/composition.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import numpy as np
+
+_SOURCE_KEYS = ("job", "social_security", "pension", "manual")
+
+
+def prorate_net_income_by_source(
+    *,
+    gross_job: np.ndarray,
+    gross_social_security: np.ndarray,
+    gross_pension: np.ndarray,
+    gross_manual: np.ndarray,
+    taxes: np.ndarray,
+) -> dict[str, np.ndarray]:
+    """Split net income by source. `taxes` are domain-signed (non-positive)."""
+    gross = {
+        "job": gross_job,
+        "social_security": gross_social_security,
+        "pension": gross_pension,
+        "manual": gross_manual,
+    }
+    total_gross = gross_job + gross_social_security + gross_pension + gross_manual
+    nets: dict[str, np.ndarray] = {}
+    for key in _SOURCE_KEYS:
+        net = np.zeros_like(total_gross, dtype=np.float64)
+        positive = total_gross > 0.0
+        share = np.zeros_like(total_gross, dtype=np.float64)
+        share[positive] = gross[key][positive] / total_gross[positive]
+        net[positive] = gross[key][positive] + taxes[positive] * share[positive]
+        nets[key] = net
+    return nets

--- a/packages/simulation/simulation/engine.py
+++ b/packages/simulation/simulation/engine.py
@@ -18,7 +18,7 @@ from simulation.npv import (
     target_general_withdrawal,
 )
 from simulation.preprocess import ProcessedPlan
-from simulation.result import SimulationResult
+from simulation.result import RawSimulationResult
 
 _SAVINGS_FLOOR = 1e-5  # tpaw _get_stock_allocation limit as savings balance → 0
 
@@ -140,7 +140,7 @@ def simulate_monthly(
     stocks_return: np.ndarray,
     bonds_return: np.ndarray,
     ran_at: datetime | None = None,
-) -> SimulationResult:
+) -> RawSimulationResult:
     ran_at = ran_at or datetime.now()
     num_runs, months = stocks_return.shape
 
@@ -228,7 +228,7 @@ def simulate_monthly(
         w_total[:, month] = drawn_essential + drawn_discretionary + drawn_general
         savings_alloc[:, month] = stock_fraction
 
-    return SimulationResult(
+    return RawSimulationResult(
         ran_at=ran_at,
         horizon_months=months,
         num_runs=num_runs,

--- a/packages/simulation/simulation/npv.py
+++ b/packages/simulation/simulation/npv.py
@@ -7,6 +7,19 @@ import numpy as np
 FloatOrArray = float | np.ndarray
 
 
+def backward_npv_including_current(
+    real_series: np.ndarray, *, one_over_1_plus_r: float
+) -> np.ndarray:
+    """NPV of `real_series[m:]` including month `m`, discounting at a constant rate."""
+    months = real_series.shape[0]
+    out = np.empty(months, dtype=np.float64)
+    running = 0.0
+    for month in range(months - 1, -1, -1):
+        running = running * one_over_1_plus_r + float(real_series[month])
+        out[month] = running
+    return out
+
+
 @dataclass(frozen=True)
 class ExpensesScale:
     discretionary: FloatOrArray

--- a/packages/simulation/simulation/preprocess.py
+++ b/packages/simulation/simulation/preprocess.py
@@ -19,6 +19,7 @@ from core.timeline import Timeline, person_end_date, project_stream
 from domain import build_monthly_cashflows
 from simulation.market_data import resolve_inflation
 from simulation.mertons import effective_mertons
+from simulation.npv import backward_npv_including_current
 from simulation.planning_returns import resolve_planning_returns
 from simulation.risk import legacy_rra, rra_by_month
 
@@ -162,13 +163,17 @@ def preprocess(
     # Backward NPV pass: income/essential discounted at the bond rate;
     # discretionary and the amortization factor at the (month-specific)
     # total-portfolio rate implied by that month's Merton allocation.
-    npv_income = np.zeros(months, dtype=np.float64)
-    npv_essential = np.zeros(months, dtype=np.float64)
+    income_including = backward_npv_including_current(
+        income_real, one_over_1_plus_r=one_over_1p_bonds
+    )
+    essential_including = backward_npv_including_current(
+        essential_real, one_over_1_plus_r=one_over_1p_bonds
+    )
+    npv_income = income_including - income_real
+    npv_essential = essential_including - essential_real
     npv_discretionary = np.zeros(months, dtype=np.float64)
     cumulative = np.zeros(months, dtype=np.float64)
 
-    income_with_current = 0.0
-    essential_with_current = 0.0
     discretionary_with_current = 0.0
     cumulative_running = 0.0
     for month in range(months - 1, -1, -1):
@@ -177,12 +182,6 @@ def preprocess(
         )
         one_over_r_portfolio = 1.0 / one_plus_r_portfolio
 
-        income_with_current = (
-            income_with_current * one_over_1p_bonds + income_real[month]
-        )
-        essential_with_current = (
-            essential_with_current * one_over_1p_bonds + essential_real[month]
-        )
         discretionary_with_current = (
             discretionary_with_current * one_over_r_portfolio
             + discretionary_real[month]
@@ -192,8 +191,6 @@ def preprocess(
         cumulative_running = cumulative_running * one_plus_g_over_r + 1.0
         cumulative[month] = cumulative_running
 
-        npv_income[month] = income_with_current - income_real[month]
-        npv_essential[month] = essential_with_current - essential_real[month]
         npv_discretionary[month] = (
             discretionary_with_current - discretionary_real[month]
         )

--- a/packages/simulation/simulation/preprocess.py
+++ b/packages/simulation/simulation/preprocess.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
+from decimal import Decimal
 
 import numpy as np
 from core.models import PersonHousehold, Plan
@@ -44,14 +45,24 @@ class ProcessedPlan:
     # "expected run" balance trajectory that establishes scheduled wealth.
     monthly_planning_stocks: float
     monthly_planning_bonds: float
+    # Composition inputs (nominal gross/tax series + inflation for wealth bands).
+    monthly_inflation: float
+    gross_job: np.ndarray
+    gross_social_security: np.ndarray
+    gross_pension: np.ndarray
+    gross_manual: np.ndarray
+    taxes: np.ndarray
+
+
+def _decimal_series_to_float64(series: Sequence[Decimal]) -> np.ndarray:
+    return np.array([float(value) for value in series], dtype=np.float64)
 
 
 def _sum_streams(streams: Sequence[TimedStream], timeline: Timeline) -> np.ndarray:
     months = timeline.horizon_months
     total = np.zeros(months, dtype=np.float64)
     for stream in streams:
-        series = project_stream(stream, timeline)
-        total += np.array([float(value) for value in series], dtype=np.float64)
+        total += _decimal_series_to_float64(project_stream(stream, timeline))
     return total
 
 
@@ -105,9 +116,7 @@ def preprocess(
 
     # Real conversion: divide month t nominal by (1 + monthly_inflation) ** t.
     deflator = (1.0 + inflation.monthly) ** np.arange(months, dtype=np.float64)
-    income_nominal = np.array(
-        [float(value) for value in cashflows.net_cashflow], dtype=np.float64
-    )
+    income_nominal = _decimal_series_to_float64(cashflows.net_cashflow)
     income_real = income_nominal / deflator
     essential_real = _sum_streams(plan.extra_essential_spending, timeline) / deflator
     discretionary_real = (
@@ -219,4 +228,12 @@ def preprocess(
         cumulative_1_plus_g_over_1_plus_r=cumulative,
         monthly_planning_stocks=monthly_stocks,
         monthly_planning_bonds=monthly_bonds,
+        monthly_inflation=inflation.monthly,
+        gross_job=_decimal_series_to_float64(cashflows.gross_job),
+        gross_social_security=_decimal_series_to_float64(
+            cashflows.gross_social_security
+        ),
+        gross_pension=_decimal_series_to_float64(cashflows.gross_pension),
+        gross_manual=_decimal_series_to_float64(cashflows.gross_manual),
+        taxes=_decimal_series_to_float64(cashflows.taxes.stored_total),
     )

--- a/packages/simulation/simulation/result.py
+++ b/packages/simulation/simulation/result.py
@@ -30,11 +30,13 @@ def _eq_ndarray_model(
     self: Any,
     other: Any,
     *,
-    expected_type: type[Any],
     array_fields: tuple[str, ...],
 ) -> bool:
-    if not isinstance(other, expected_type):
-        return NotImplemented
+    """Compare two same-typed models whose ndarray fields break Pydantic's `==`.
+
+    Callers guard the type check (returning `NotImplemented` on mismatch) so this
+    helper always compares two instances of the same model and returns a real bool.
+    """
     if not all(
         np.array_equal(getattr(self, field), getattr(other, field))
         for field in array_fields
@@ -62,12 +64,9 @@ class RawSimulationResult(BaseModel):
     def __eq__(self, other: Any) -> bool:
         # Pydantic's generated __eq__ compares fields with `==`, which raises
         # on np.ndarray fields ("truth value of an array is ambiguous").
-        return _eq_ndarray_model(
-            self,
-            other,
-            expected_type=RawSimulationResult,
-            array_fields=RAW_ARRAY_FIELDS,
-        )
+        if not isinstance(other, RawSimulationResult):
+            return NotImplemented
+        return _eq_ndarray_model(self, other, array_fields=RAW_ARRAY_FIELDS)
 
 
 class SimulationResult(BaseModel):
@@ -92,9 +91,6 @@ class SimulationResult(BaseModel):
     engine_version: str = ENGINE_VERSION
 
     def __eq__(self, other: Any) -> bool:
-        return _eq_ndarray_model(
-            self,
-            other,
-            expected_type=SimulationResult,
-            array_fields=_PUBLIC_ARRAY_FIELDS,
-        )
+        if not isinstance(other, SimulationResult):
+            return NotImplemented
+        return _eq_ndarray_model(self, other, array_fields=_PUBLIC_ARRAY_FIELDS)

--- a/packages/simulation/simulation/result.py
+++ b/packages/simulation/simulation/result.py
@@ -6,9 +6,9 @@ from typing import Any
 import numpy as np
 from pydantic import BaseModel, ConfigDict
 
-ENGINE_VERSION = "phase3b"
+ENGINE_VERSION = "phase3d"
 
-_ARRAY_FIELDS = (
+_RAW_ARRAY_FIELDS = (
     "balance_start",
     "withdrawals_essential",
     "withdrawals_discretionary",
@@ -17,8 +17,16 @@ _ARRAY_FIELDS = (
     "savings_stock_allocation",
 )
 
+_PUBLIC_ARRAY_FIELDS = (
+    *_RAW_ARRAY_FIELDS,
+    "wealth_job",
+    "wealth_social_security",
+    "wealth_pension",
+    "wealth_manual",
+)
 
-class SimulationResult(BaseModel):
+
+class RawSimulationResult(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     ran_at: datetime
@@ -37,14 +45,49 @@ class SimulationResult(BaseModel):
         # Pydantic's generated __eq__ compares fields with `==`, which raises
         # on np.ndarray fields ("truth value of an array is ambiguous").
         # Compare array fields with np.array_equal and everything else normally.
+        if not isinstance(other, RawSimulationResult):
+            return NotImplemented
+        if not all(
+            np.array_equal(getattr(self, field), getattr(other, field))
+            for field in _RAW_ARRAY_FIELDS
+        ):
+            return False
+        scalar_fields = set(type(self).model_fields) - set(_RAW_ARRAY_FIELDS)
+        return all(
+            getattr(self, field) == getattr(other, field) for field in scalar_fields
+        )
+
+
+class SimulationResult(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    ran_at: datetime
+    horizon_months: int
+    num_runs: int
+    percentiles: list[int]
+    start_month: tuple[int, int]
+    balance_start: np.ndarray
+    withdrawals_essential: np.ndarray
+    withdrawals_discretionary: np.ndarray
+    withdrawals_general: np.ndarray
+    withdrawals_total: np.ndarray
+    savings_stock_allocation: np.ndarray
+    wealth_job: np.ndarray
+    wealth_social_security: np.ndarray
+    wealth_pension: np.ndarray
+    wealth_manual: np.ndarray
+    num_runs_insufficient: int
+    engine_version: str = ENGINE_VERSION
+
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, SimulationResult):
             return NotImplemented
         if not all(
             np.array_equal(getattr(self, field), getattr(other, field))
-            for field in _ARRAY_FIELDS
+            for field in _PUBLIC_ARRAY_FIELDS
         ):
             return False
-        scalar_fields = set(type(self).model_fields) - set(_ARRAY_FIELDS)
+        scalar_fields = set(type(self).model_fields) - set(_PUBLIC_ARRAY_FIELDS)
         return all(
             getattr(self, field) == getattr(other, field) for field in scalar_fields
         )

--- a/packages/simulation/simulation/result.py
+++ b/packages/simulation/simulation/result.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict
 
 ENGINE_VERSION = "phase3d"
 
-_RAW_ARRAY_FIELDS = (
+RAW_ARRAY_FIELDS = (
     "balance_start",
     "withdrawals_essential",
     "withdrawals_discretionary",
@@ -18,12 +18,30 @@ _RAW_ARRAY_FIELDS = (
 )
 
 _PUBLIC_ARRAY_FIELDS = (
-    *_RAW_ARRAY_FIELDS,
+    *RAW_ARRAY_FIELDS,
     "wealth_job",
     "wealth_social_security",
     "wealth_pension",
     "wealth_manual",
 )
+
+
+def _eq_ndarray_model(
+    self: Any,
+    other: Any,
+    *,
+    expected_type: type[Any],
+    array_fields: tuple[str, ...],
+) -> bool:
+    if not isinstance(other, expected_type):
+        return NotImplemented
+    if not all(
+        np.array_equal(getattr(self, field), getattr(other, field))
+        for field in array_fields
+    ):
+        return False
+    scalar_fields = set(type(self).model_fields) - set(array_fields)
+    return all(getattr(self, field) == getattr(other, field) for field in scalar_fields)
 
 
 class RawSimulationResult(BaseModel):
@@ -44,17 +62,11 @@ class RawSimulationResult(BaseModel):
     def __eq__(self, other: Any) -> bool:
         # Pydantic's generated __eq__ compares fields with `==`, which raises
         # on np.ndarray fields ("truth value of an array is ambiguous").
-        # Compare array fields with np.array_equal and everything else normally.
-        if not isinstance(other, RawSimulationResult):
-            return NotImplemented
-        if not all(
-            np.array_equal(getattr(self, field), getattr(other, field))
-            for field in _RAW_ARRAY_FIELDS
-        ):
-            return False
-        scalar_fields = set(type(self).model_fields) - set(_RAW_ARRAY_FIELDS)
-        return all(
-            getattr(self, field) == getattr(other, field) for field in scalar_fields
+        return _eq_ndarray_model(
+            self,
+            other,
+            expected_type=RawSimulationResult,
+            array_fields=RAW_ARRAY_FIELDS,
         )
 
 
@@ -80,14 +92,9 @@ class SimulationResult(BaseModel):
     engine_version: str = ENGINE_VERSION
 
     def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, SimulationResult):
-            return NotImplemented
-        if not all(
-            np.array_equal(getattr(self, field), getattr(other, field))
-            for field in _PUBLIC_ARRAY_FIELDS
-        ):
-            return False
-        scalar_fields = set(type(self).model_fields) - set(_PUBLIC_ARRAY_FIELDS)
-        return all(
-            getattr(self, field) == getattr(other, field) for field in scalar_fields
+        return _eq_ndarray_model(
+            self,
+            other,
+            expected_type=SimulationResult,
+            array_fields=_PUBLIC_ARRAY_FIELDS,
         )

--- a/packages/simulation/simulation/stub.py
+++ b/packages/simulation/simulation/stub.py
@@ -7,7 +7,7 @@ from core.models import Plan
 from simulation.engine import simulate_monthly
 from simulation.market_data import build_return_paths
 from simulation.preprocess import preprocess
-from simulation.result import SimulationResult
+from simulation.result import RawSimulationResult
 
 
 def run_simulation(
@@ -20,7 +20,7 @@ def run_simulation(
     now: datetime | None = None,
     fred_api_key: str | None = None,
     eod_api_key: str | None = None,
-) -> SimulationResult:
+) -> RawSimulationResult:
     _ = percentiles  # reserved for Phase 3d aggregation
     today = today or date.today()
     ran_at = ran_at or datetime.now()

--- a/packages/simulation/simulation/stub.py
+++ b/packages/simulation/simulation/stub.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
-import numpy as np
 from core.models import Plan, normalize_percentiles
 
-from domain import build_monthly_cashflows
 from simulation.aggregate import build_public_result
 from simulation.composition import wealth_by_income_source
 from simulation.engine import simulate_monthly
-from simulation.market_data import build_return_paths, resolve_inflation
+from simulation.market_data import build_return_paths
 from simulation.preprocess import preprocess
 from simulation.result import SimulationResult
 
@@ -27,10 +25,15 @@ def run_simulation(
 ) -> SimulationResult:
     today = today or date.today()
     ran_at = ran_at or datetime.now()
-    resolved = normalize_percentiles(
-        percentiles if percentiles is not None else plan.advanced.percentiles
+    resolved = (
+        normalize_percentiles(percentiles)
+        if percentiles is not None
+        else plan.advanced.percentiles
     )
 
+    # `now` (tz-aware, drives market-data cache staleness) is intentionally
+    # independent from `ran_at` (naive, only stamps the result) — the resolvers
+    # default `now` to `datetime.now(tz=UTC)` on their own when unset.
     processed = preprocess(
         plan,
         today=today,
@@ -47,29 +50,13 @@ def run_simulation(
         ran_at=ran_at,
     )
 
-    cashflows = build_monthly_cashflows(plan, today=today)
-    inflation = resolve_inflation(
-        plan,
-        today=today,
-        allow_refresh=allow_refresh,
-        now=now,
-        api_key=fred_api_key,
-    )
     composition = wealth_by_income_source(
-        gross_job=np.array([float(v) for v in cashflows.gross_job], dtype=np.float64),
-        gross_social_security=np.array(
-            [float(v) for v in cashflows.gross_social_security], dtype=np.float64
-        ),
-        gross_pension=np.array(
-            [float(v) for v in cashflows.gross_pension], dtype=np.float64
-        ),
-        gross_manual=np.array(
-            [float(v) for v in cashflows.gross_manual], dtype=np.float64
-        ),
-        taxes=np.array(
-            [float(v) for v in cashflows.taxes.stored_total], dtype=np.float64
-        ),
-        monthly_inflation=inflation.monthly,
+        gross_job=processed.gross_job,
+        gross_social_security=processed.gross_social_security,
+        gross_pension=processed.gross_pension,
+        gross_manual=processed.gross_manual,
+        taxes=processed.taxes,
+        monthly_inflation=processed.monthly_inflation,
         monthly_bond_rate=processed.monthly_planning_bonds,
     )
 

--- a/packages/simulation/simulation/stub.py
+++ b/packages/simulation/simulation/stub.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
-from core.models import Plan
+import numpy as np
+from core.models import Plan, normalize_percentiles
 
+from domain import build_monthly_cashflows
+from simulation.aggregate import build_public_result
+from simulation.composition import wealth_by_income_source
 from simulation.engine import simulate_monthly
-from simulation.market_data import build_return_paths
+from simulation.market_data import build_return_paths, resolve_inflation
 from simulation.preprocess import preprocess
-from simulation.result import RawSimulationResult
+from simulation.result import SimulationResult
 
 
 def run_simulation(
@@ -20,14 +24,13 @@ def run_simulation(
     now: datetime | None = None,
     fred_api_key: str | None = None,
     eod_api_key: str | None = None,
-) -> RawSimulationResult:
-    _ = percentiles  # reserved for Phase 3d aggregation
+) -> SimulationResult:
     today = today or date.today()
     ran_at = ran_at or datetime.now()
+    resolved = normalize_percentiles(
+        percentiles if percentiles is not None else plan.advanced.percentiles
+    )
 
-    # `now` (tz-aware, drives market-data cache staleness) is intentionally
-    # independent from `ran_at` (naive, only stamps the result) — the resolvers
-    # default `now` to `datetime.now(tz=UTC)` on their own when unset.
     processed = preprocess(
         plan,
         today=today,
@@ -37,9 +40,42 @@ def run_simulation(
         eod_api_key=eod_api_key,
     )
     paths = build_return_paths(plan, months_per_run=processed.months, today=today)
-    return simulate_monthly(
+    raw = simulate_monthly(
         processed,
         stocks_return=paths.stocks_log_to_simple(),
         bonds_return=paths.bonds_log_to_simple(),
         ran_at=ran_at,
+    )
+
+    cashflows = build_monthly_cashflows(plan, today=today)
+    inflation = resolve_inflation(
+        plan,
+        today=today,
+        allow_refresh=allow_refresh,
+        now=now,
+        api_key=fred_api_key,
+    )
+    composition = wealth_by_income_source(
+        gross_job=np.array([float(v) for v in cashflows.gross_job], dtype=np.float64),
+        gross_social_security=np.array(
+            [float(v) for v in cashflows.gross_social_security], dtype=np.float64
+        ),
+        gross_pension=np.array(
+            [float(v) for v in cashflows.gross_pension], dtype=np.float64
+        ),
+        gross_manual=np.array(
+            [float(v) for v in cashflows.gross_manual], dtype=np.float64
+        ),
+        taxes=np.array(
+            [float(v) for v in cashflows.taxes.stored_total], dtype=np.float64
+        ),
+        monthly_inflation=inflation.monthly,
+        monthly_bond_rate=processed.monthly_planning_bonds,
+    )
+
+    return build_public_result(
+        raw,
+        percentiles=resolved,
+        composition=composition,
+        start_month=(today.year, today.month),
     )

--- a/packages/simulation/simulation/stub.py
+++ b/packages/simulation/simulation/stub.py
@@ -25,10 +25,8 @@ def run_simulation(
 ) -> SimulationResult:
     today = today or date.today()
     ran_at = ran_at or datetime.now()
-    resolved = (
-        normalize_percentiles(percentiles)
-        if percentiles is not None
-        else plan.advanced.percentiles
+    resolved = normalize_percentiles(
+        percentiles if percentiles is not None else plan.advanced.percentiles
     )
 
     # `now` (tz-aware, drives market-data cache staleness) is intentionally

--- a/packages/simulation/tests/test_aggregate.py
+++ b/packages/simulation/tests/test_aggregate.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+import numpy as np
+from simulation.aggregate import aggregate_percentiles
+from simulation.result import RawSimulationResult
+
+
+def _raw(*, balance_start: np.ndarray) -> RawSimulationResult:
+    num_runs, months = balance_start.shape
+    zeros = np.zeros((num_runs, months), dtype=np.float64)
+    return RawSimulationResult(
+        ran_at=datetime(2026, 1, 1),
+        horizon_months=months,
+        num_runs=num_runs,
+        balance_start=balance_start,
+        withdrawals_essential=zeros,
+        withdrawals_discretionary=zeros,
+        withdrawals_general=zeros,
+        withdrawals_total=balance_start
+        * 0.1,  # distinct from balance for mapping check
+        savings_stock_allocation=zeros,
+        num_runs_insufficient=0,
+    )
+
+
+def test_aggregate_percentiles_reduces_each_array_field_along_runs():
+    # Column 0 values [1, 2, 3]; column 1 [10, 20, 30]
+    balance_start = np.array([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]], dtype=np.float64)
+    percentiles = [0, 50, 100]
+    raw = _raw(balance_start=balance_start)
+
+    reduced = aggregate_percentiles(raw, percentiles=percentiles)
+
+    assert reduced.balance_start.shape == (len(percentiles), raw.horizon_months)
+    np.testing.assert_allclose(
+        reduced.balance_start,
+        np.percentile(raw.balance_start, percentiles, axis=0),
+    )
+    np.testing.assert_allclose(
+        reduced.withdrawals_total,
+        np.percentile(raw.withdrawals_total, percentiles, axis=0),
+    )
+    assert reduced.percentiles == percentiles
+    assert reduced.num_runs == raw.num_runs

--- a/packages/simulation/tests/test_aggregate.py
+++ b/packages/simulation/tests/test_aggregate.py
@@ -3,56 +3,63 @@ from datetime import datetime
 import numpy as np
 from simulation.aggregate import build_public_result
 from simulation.composition import WealthBySource
-from simulation.result import RawSimulationResult
+from simulation.result import RAW_ARRAY_FIELDS, RawSimulationResult
+
+_NUM_RUNS = 3
+_MONTHS = 2
+# One distinct 2-D array per raw field so a swapped field->field mapping in
+# build_public_result cannot pass. Runs ascend so percentiles [0, 50, 100]
+# pick min/median/max deterministically.
+_BASE = np.array([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]], dtype=np.float64)
+_RAW_ARRAYS = {
+    field: _BASE * float(index + 1) for index, field in enumerate(RAW_ARRAY_FIELDS)
+}
 
 
-def _raw(*, balance_start: np.ndarray) -> RawSimulationResult:
-    num_runs, months = balance_start.shape
-    zeros = np.zeros((num_runs, months), dtype=np.float64)
+def _raw() -> RawSimulationResult:
     return RawSimulationResult(
         ran_at=datetime(2026, 1, 1),
-        horizon_months=months,
-        num_runs=num_runs,
-        balance_start=balance_start,
-        withdrawals_essential=zeros,
-        withdrawals_discretionary=zeros,
-        withdrawals_general=zeros,
-        withdrawals_total=balance_start
-        * 0.1,  # distinct from balance for mapping check
-        savings_stock_allocation=zeros,
+        horizon_months=_MONTHS,
+        num_runs=_NUM_RUNS,
         num_runs_insufficient=0,
+        balance_start=_RAW_ARRAYS["balance_start"],
+        withdrawals_essential=_RAW_ARRAYS["withdrawals_essential"],
+        withdrawals_discretionary=_RAW_ARRAYS["withdrawals_discretionary"],
+        withdrawals_general=_RAW_ARRAYS["withdrawals_general"],
+        withdrawals_total=_RAW_ARRAYS["withdrawals_total"],
+        savings_stock_allocation=_RAW_ARRAYS["savings_stock_allocation"],
     )
 
 
 def test_build_public_result_reduces_each_array_field_along_runs():
-    # Column 0 values [1, 2, 3]; column 1 [10, 20, 30]
-    balance_start = np.array([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]], dtype=np.float64)
-    percentiles = [0, 50, 100]
-    raw = _raw(balance_start=balance_start)
-    months = raw.horizon_months
+    percentiles = [0, 50, 100]  # min / median / max
+    start_month = (2026, 1)
+    raw = _raw()
     composition = WealthBySource(
-        job=np.zeros(months, dtype=np.float64),
-        social_security=np.zeros(months, dtype=np.float64),
-        pension=np.zeros(months, dtype=np.float64),
-        manual=np.zeros(months, dtype=np.float64),
+        job=np.zeros(_MONTHS, dtype=np.float64),
+        social_security=np.zeros(_MONTHS, dtype=np.float64),
+        pension=np.zeros(_MONTHS, dtype=np.float64),
+        manual=np.zeros(_MONTHS, dtype=np.float64),
     )
 
     result = build_public_result(
         raw,
         percentiles=percentiles,
         composition=composition,
-        start_month=(2026, 1),
+        start_month=start_month,
     )
 
-    assert result.balance_start.shape == (len(percentiles), raw.horizon_months)
-    np.testing.assert_allclose(
-        result.balance_start,
-        np.percentile(raw.balance_start, percentiles, axis=0),
-    )
-    np.testing.assert_allclose(
-        result.withdrawals_total,
-        np.percentile(raw.withdrawals_total, percentiles, axis=0),
-    )
+    for field, raw_array in _RAW_ARRAYS.items():
+        reduced = getattr(result, field)
+        assert reduced.shape == (len(percentiles), _MONTHS)
+        np.testing.assert_allclose(
+            reduced, np.percentile(raw_array, percentiles, axis=0)
+        )
+
+    # Hand-derived: for 3 runs ascending per column, [0, 50, 100] percentiles are
+    # exactly min/median/max, i.e. the raw rows unchanged — independent of numpy.
+    first_field = RAW_ARRAY_FIELDS[0]
+    np.testing.assert_allclose(getattr(result, first_field), _RAW_ARRAYS[first_field])
     assert result.percentiles == percentiles
-    assert result.num_runs == raw.num_runs
-    assert result.start_month == (2026, 1)
+    assert result.num_runs == _NUM_RUNS
+    assert result.start_month == start_month

--- a/packages/simulation/tests/test_aggregate.py
+++ b/packages/simulation/tests/test_aggregate.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 
 import numpy as np
-from simulation.aggregate import aggregate_percentiles
+from simulation.aggregate import build_public_result
+from simulation.composition import WealthBySource
 from simulation.result import RawSimulationResult
 
 
@@ -23,22 +24,35 @@ def _raw(*, balance_start: np.ndarray) -> RawSimulationResult:
     )
 
 
-def test_aggregate_percentiles_reduces_each_array_field_along_runs():
+def test_build_public_result_reduces_each_array_field_along_runs():
     # Column 0 values [1, 2, 3]; column 1 [10, 20, 30]
     balance_start = np.array([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]], dtype=np.float64)
     percentiles = [0, 50, 100]
     raw = _raw(balance_start=balance_start)
+    months = raw.horizon_months
+    composition = WealthBySource(
+        job=np.zeros(months, dtype=np.float64),
+        social_security=np.zeros(months, dtype=np.float64),
+        pension=np.zeros(months, dtype=np.float64),
+        manual=np.zeros(months, dtype=np.float64),
+    )
 
-    reduced = aggregate_percentiles(raw, percentiles=percentiles)
+    result = build_public_result(
+        raw,
+        percentiles=percentiles,
+        composition=composition,
+        start_month=(2026, 1),
+    )
 
-    assert reduced.balance_start.shape == (len(percentiles), raw.horizon_months)
+    assert result.balance_start.shape == (len(percentiles), raw.horizon_months)
     np.testing.assert_allclose(
-        reduced.balance_start,
+        result.balance_start,
         np.percentile(raw.balance_start, percentiles, axis=0),
     )
     np.testing.assert_allclose(
-        reduced.withdrawals_total,
+        result.withdrawals_total,
         np.percentile(raw.withdrawals_total, percentiles, axis=0),
     )
-    assert reduced.percentiles == percentiles
-    assert reduced.num_runs == raw.num_runs
+    assert result.percentiles == percentiles
+    assert result.num_runs == raw.num_runs
+    assert result.start_month == (2026, 1)

--- a/packages/simulation/tests/test_backward_npv.py
+++ b/packages/simulation/tests/test_backward_npv.py
@@ -1,0 +1,19 @@
+import numpy as np
+from simulation.npv import backward_npv_including_current
+
+
+def test_backward_npv_including_current_matches_hand_recurrence():
+    real_series = np.array([10.0, 20.0, 30.0], dtype=np.float64)
+    one_over_1_plus_r = 0.5  # extreme rate so arithmetic is obvious
+
+    # Hand recurrence (last month → first), same as preprocess income pass:
+    # m2: 0 * 0.5 + 30 = 30
+    # m1: 30 * 0.5 + 20 = 35
+    # m0: 35 * 0.5 + 10 = 27.5
+    expected = np.array([27.5, 35.0, 30.0], dtype=np.float64)
+
+    result = backward_npv_including_current(
+        real_series, one_over_1_plus_r=one_over_1_plus_r
+    )
+
+    np.testing.assert_allclose(result, expected)

--- a/packages/simulation/tests/test_composition.py
+++ b/packages/simulation/tests/test_composition.py
@@ -1,5 +1,6 @@
 import numpy as np
-from simulation.composition import prorate_net_income_by_source
+from simulation.composition import prorate_net_income_by_source, wealth_by_income_source
+from simulation.npv import backward_npv_including_current
 
 
 def test_prorated_nets_sum_to_net_cashflow_when_gross_positive():
@@ -38,3 +39,41 @@ def test_proration_zero_gross_month_yields_zero_nets():
 
     for series in nets.values():
         np.testing.assert_allclose(series, zeros)
+
+
+def test_wealth_by_source_sums_to_combined_income_wealth():
+    months = 4
+    gross_job = np.array([100.0, 100.0, 0.0, 0.0], dtype=np.float64)
+    gross_ss = np.array([0.0, 0.0, 50.0, 50.0], dtype=np.float64)
+    zeros = np.zeros(months, dtype=np.float64)
+    taxes = np.array([-20.0, -20.0, -5.0, -5.0], dtype=np.float64)
+    monthly_inflation = 0.0
+    monthly_bond = 0.01
+    one_over = 1.0 / (1.0 + monthly_bond)
+
+    wealth = wealth_by_income_source(
+        gross_job=gross_job,
+        gross_social_security=gross_ss,
+        gross_pension=zeros,
+        gross_manual=zeros,
+        taxes=taxes,
+        monthly_inflation=monthly_inflation,
+        monthly_bond_rate=monthly_bond,
+    )
+
+    nets = prorate_net_income_by_source(
+        gross_job=gross_job,
+        gross_social_security=gross_ss,
+        gross_pension=zeros,
+        gross_manual=zeros,
+        taxes=taxes,
+    )
+    combined_nominal = sum(nets[k] for k in nets)
+    deflator = (1.0 + monthly_inflation) ** np.arange(months, dtype=np.float64)
+    combined_real = combined_nominal / deflator
+    expected_total = backward_npv_including_current(
+        combined_real, one_over_1_plus_r=one_over
+    )
+
+    actual_total = wealth.job + wealth.social_security + wealth.pension + wealth.manual
+    np.testing.assert_allclose(actual_total, expected_total)

--- a/packages/simulation/tests/test_composition.py
+++ b/packages/simulation/tests/test_composition.py
@@ -1,5 +1,37 @@
+from datetime import date
+from decimal import Decimal
+
 import numpy as np
-from simulation.composition import prorate_net_income_by_source, wealth_by_income_source
+from core.defaults import default_plan
+from core.job import Job
+from core.models import Household, PersonHousehold, Plan, Portfolio
+from core.streams import CalendarMonthBoundary
+from simulation.composition import (
+    WealthBySource,
+    prorate_net_income_by_source,
+    wealth_by_income_source,
+)
+from simulation.preprocess import ProcessedPlan, preprocess
+
+
+def _plan_with_job_income() -> Plan:
+    """Minimal plan with positive gross job income across the horizon."""
+    base = default_plan()
+    job = Job(
+        annual_income=Decimal("120_000"),
+        end=CalendarMonthBoundary(year=2045, month=12),
+    )
+    person1 = PersonHousehold(
+        birth_month=1,
+        birth_year=1983,
+        jobs=[job],
+        social_security=base.household.person1.social_security,
+    )
+    return Plan(
+        name="Composition Integration",
+        household=Household(person1=person1, person2=base.household.person2),
+        portfolio=Portfolio(current_savings_balance=Decimal("500_000")),
+    )
 
 
 def _npv_including_current_closed_form(
@@ -109,3 +141,56 @@ def test_proration_zero_gross_months_stay_zero_across_horizon():
 
     for series in nets.values():
         np.testing.assert_allclose(series, zeros)
+
+
+def _wealth_from_processed(processed: ProcessedPlan) -> WealthBySource:
+    return wealth_by_income_source(
+        gross_job=processed.gross_job,
+        gross_social_security=processed.gross_social_security,
+        gross_pension=processed.gross_pension,
+        gross_manual=processed.gross_manual,
+        taxes=processed.taxes,
+        monthly_inflation=processed.monthly_inflation,
+        monthly_bond_rate=processed.monthly_planning_bonds,
+    )
+
+
+def test_wealth_bands_reconcile_with_preprocess_income_npv():
+    # Spec §7.2: Σ wealth_s[m] == npv_income_without_current[m] + income_real[m]
+    # when composition and preprocess share the same discount path and net total.
+    # Zero-gross months (spec §7.1) omit residual taxes from composition, so only
+    # assert months where total_gross > 0.
+    today = date(2026, 1, 1)
+    processed = preprocess(_plan_with_job_income(), today=today)
+    wealth = _wealth_from_processed(processed)
+
+    total_gross = (
+        processed.gross_job
+        + processed.gross_social_security
+        + processed.gross_pension
+        + processed.gross_manual
+    )
+    positive_gross = total_gross > 0.0
+    assert np.any(positive_gross), "fixture must include positive-gross months"
+
+    wealth_total = wealth.job + wealth.social_security + wealth.pension + wealth.manual
+    expected = processed.npv_income_without_current + processed.income_real
+    np.testing.assert_allclose(wealth_total[positive_gross], expected[positive_gross])
+
+
+def test_month_zero_stack_matches_total_portfolio_wealth():
+    # Spec §9.3: savings + income wealth matches hand total at month 0.
+    today = date(2026, 1, 1)
+    processed = preprocess(_plan_with_job_income(), today=today)
+    wealth = _wealth_from_processed(processed)
+
+    income_wealth_0 = processed.npv_income_without_current[0] + processed.income_real[0]
+    stacked_0 = (
+        processed.starting_balance
+        + wealth.job[0]
+        + wealth.social_security[0]
+        + wealth.pension[0]
+        + wealth.manual[0]
+    )
+    hand_total_0 = processed.starting_balance + income_wealth_0
+    np.testing.assert_allclose(stacked_0, hand_total_0)

--- a/packages/simulation/tests/test_composition.py
+++ b/packages/simulation/tests/test_composition.py
@@ -1,0 +1,40 @@
+import numpy as np
+from simulation.composition import prorate_net_income_by_source
+
+
+def test_prorated_nets_sum_to_net_cashflow_when_gross_positive():
+    gross_job = np.array([80.0], dtype=np.float64)
+    gross_ss = np.array([20.0], dtype=np.float64)
+    gross_pension = np.array([0.0], dtype=np.float64)
+    gross_manual = np.array([0.0], dtype=np.float64)
+    # Domain stores taxes as non-positive.
+    taxes = np.array([-10.0], dtype=np.float64)
+    total_gross = gross_job + gross_ss + gross_pension + gross_manual
+    net_cashflow = total_gross + taxes
+
+    nets = prorate_net_income_by_source(
+        gross_job=gross_job,
+        gross_social_security=gross_ss,
+        gross_pension=gross_pension,
+        gross_manual=gross_manual,
+        taxes=taxes,
+    )
+
+    summed = nets["job"] + nets["social_security"] + nets["pension"] + nets["manual"]
+    np.testing.assert_allclose(summed, net_cashflow)
+
+
+def test_proration_zero_gross_month_yields_zero_nets():
+    zeros = np.array([0.0], dtype=np.float64)
+    taxes = np.array([-5.0], dtype=np.float64)  # residual tax ignored for composition
+
+    nets = prorate_net_income_by_source(
+        gross_job=zeros,
+        gross_social_security=zeros.copy(),
+        gross_pension=zeros.copy(),
+        gross_manual=zeros.copy(),
+        taxes=taxes,
+    )
+
+    for series in nets.values():
+        np.testing.assert_allclose(series, zeros)

--- a/packages/simulation/tests/test_composition.py
+++ b/packages/simulation/tests/test_composition.py
@@ -1,6 +1,24 @@
 import numpy as np
 from simulation.composition import prorate_net_income_by_source, wealth_by_income_source
-from simulation.npv import backward_npv_including_current
+
+
+def _npv_including_current_closed_form(
+    real_series: np.ndarray, *, one_over: float
+) -> np.ndarray:
+    """Independent expected NPV: sum of each month's real value discounted back.
+
+    Deliberately does NOT call the production `backward_npv_including_current`
+    so the reconciliation test verifies composition's discounting rather than
+    trivially restating the helper it uses internally.
+    """
+    months = len(real_series)
+    return np.array(
+        [
+            sum(real_series[k] * one_over ** (k - m) for k in range(m, months))
+            for m in range(months)
+        ],
+        dtype=np.float64,
+    )
 
 
 def test_prorated_nets_sum_to_net_cashflow_when_gross_positive():
@@ -41,13 +59,15 @@ def test_proration_zero_gross_month_yields_zero_nets():
         np.testing.assert_allclose(series, zeros)
 
 
-def test_wealth_by_source_sums_to_combined_income_wealth():
+def test_wealth_by_source_sums_to_independently_discounted_combined_income():
     months = 4
+    # total_gross is positive every month, so combined nets == net cashflow and
+    # the wealth bands must reconcile with the combined-income NPV.
     gross_job = np.array([100.0, 100.0, 0.0, 0.0], dtype=np.float64)
     gross_ss = np.array([0.0, 0.0, 50.0, 50.0], dtype=np.float64)
     zeros = np.zeros(months, dtype=np.float64)
     taxes = np.array([-20.0, -20.0, -5.0, -5.0], dtype=np.float64)
-    monthly_inflation = 0.0
+    monthly_inflation = 0.02  # nonzero so the deflator is actually exercised
     monthly_bond = 0.01
     one_over = 1.0 / (1.0 + monthly_bond)
 
@@ -61,19 +81,31 @@ def test_wealth_by_source_sums_to_combined_income_wealth():
         monthly_bond_rate=monthly_bond,
     )
 
-    nets = prorate_net_income_by_source(
-        gross_job=gross_job,
-        gross_social_security=gross_ss,
-        gross_pension=zeros,
-        gross_manual=zeros,
-        taxes=taxes,
-    )
-    combined_nominal = sum(nets[k] for k in nets)
+    combined_nominal = gross_job + gross_ss + taxes
     deflator = (1.0 + monthly_inflation) ** np.arange(months, dtype=np.float64)
     combined_real = combined_nominal / deflator
-    expected_total = backward_npv_including_current(
-        combined_real, one_over_1_plus_r=one_over
+    expected_total = _npv_including_current_closed_form(
+        combined_real, one_over=one_over
     )
 
     actual_total = wealth.job + wealth.social_security + wealth.pension + wealth.manual
     np.testing.assert_allclose(actual_total, expected_total)
+
+
+def test_proration_zero_gross_months_stay_zero_across_horizon():
+    # Composition intentionally drops residual taxes when a month has no gross
+    # income (spec §7.1): those months contribute nothing to any wealth band.
+    months = 3
+    zeros = np.zeros(months, dtype=np.float64)
+    taxes = np.array([-5.0, -3.0, -1.0], dtype=np.float64)
+
+    nets = prorate_net_income_by_source(
+        gross_job=zeros,
+        gross_social_security=zeros.copy(),
+        gross_pension=zeros.copy(),
+        gross_manual=zeros.copy(),
+        taxes=taxes,
+    )
+
+    for series in nets.values():
+        np.testing.assert_allclose(series, zeros)

--- a/packages/simulation/tests/test_engine.py
+++ b/packages/simulation/tests/test_engine.py
@@ -28,6 +28,12 @@ def _flat_processed(
         cumulative_1_plus_g_over_1_plus_r=np.arange(months, 0, -1, dtype=np.float64),
         monthly_planning_stocks=0.0,
         monthly_planning_bonds=0.0,
+        monthly_inflation=0.0,
+        gross_job=zeros.copy(),
+        gross_social_security=zeros.copy(),
+        gross_pension=zeros.copy(),
+        gross_manual=zeros.copy(),
+        taxes=zeros.copy(),
     )
 
 

--- a/packages/simulation/tests/test_preprocess.py
+++ b/packages/simulation/tests/test_preprocess.py
@@ -26,6 +26,11 @@ def test_preprocess_shapes_and_basic_invariants():
     # Allocation is a fraction in [0, 1].
     assert np.all(processed.stock_allocation_total_portfolio >= 0.0)
     assert np.all(processed.stock_allocation_total_portfolio <= 1.0)
+    assert processed.gross_job.shape == (months,)
+    assert processed.gross_social_security.shape == (months,)
+    assert processed.gross_pension.shape == (months,)
+    assert processed.gross_manual.shape == (months,)
+    assert processed.taxes.shape == (months,)
 
 
 def test_legacy_npv_zero_when_no_legacy_target():

--- a/packages/simulation/tests/test_result.py
+++ b/packages/simulation/tests/test_result.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import numpy as np
-from simulation.result import RawSimulationResult
+from simulation.result import RawSimulationResult, SimulationResult
 
 
 def test_raw_simulation_result_holds_per_run_arrays():
@@ -64,5 +64,48 @@ def test_results_with_differing_scalars_compare_unequal():
 
     first = _make_result(balance_start=balance_start, num_runs_insufficient=0)
     second = _make_result(balance_start=balance_start, num_runs_insufficient=1)
+
+    assert first != second
+
+
+def _make_public_result(*, balance_start: np.ndarray) -> SimulationResult:
+    percentiles = [5, 50, 95]
+    num_runs, months = balance_start.shape
+    wealth = np.zeros(months, dtype=np.float64)
+    return SimulationResult(
+        ran_at=datetime(2026, 1, 1),
+        horizon_months=months,
+        num_runs=num_runs,
+        percentiles=percentiles,
+        start_month=(2026, 1),
+        balance_start=balance_start,
+        withdrawals_essential=np.zeros((len(percentiles), months), dtype=np.float64),
+        withdrawals_discretionary=np.zeros(
+            (len(percentiles), months), dtype=np.float64
+        ),
+        withdrawals_general=np.zeros((len(percentiles), months), dtype=np.float64),
+        withdrawals_total=np.zeros((len(percentiles), months), dtype=np.float64),
+        savings_stock_allocation=np.zeros((len(percentiles), months), dtype=np.float64),
+        wealth_job=wealth,
+        wealth_social_security=wealth.copy(),
+        wealth_pension=wealth.copy(),
+        wealth_manual=wealth.copy(),
+        num_runs_insufficient=0,
+    )
+
+
+def test_public_simulation_result_equality_compares_ndarray_fields():
+    balance_start = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float64)
+
+    first = _make_public_result(balance_start=balance_start)
+    second = _make_public_result(balance_start=balance_start.copy())
+
+    assert first == second
+
+
+def test_public_simulation_result_inequality_on_differing_wealth_band():
+    balance_start = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float64)
+    first = _make_public_result(balance_start=balance_start)
+    second = first.model_copy(update={"wealth_job": first.wealth_job + 1.0})
 
     assert first != second

--- a/packages/simulation/tests/test_result.py
+++ b/packages/simulation/tests/test_result.py
@@ -1,15 +1,15 @@
 from datetime import datetime
 
 import numpy as np
-from simulation.result import SimulationResult
+from simulation.result import RawSimulationResult
 
 
-def test_simulation_result_holds_per_run_arrays():
+def test_raw_simulation_result_holds_per_run_arrays():
     num_runs, months = 3, 4
     expected_insufficient = 0
     zeros = np.zeros((num_runs, months), dtype=np.float64)
 
-    result = SimulationResult(
+    result = RawSimulationResult(
         ran_at=datetime(2026, 1, 1),
         horizon_months=months,
         num_runs=num_runs,
@@ -29,7 +29,7 @@ def test_simulation_result_holds_per_run_arrays():
 def _make_result(*, balance_start: np.ndarray, num_runs_insufficient: int = 0):
     num_runs, months = balance_start.shape
     other_zeros = np.zeros((num_runs, months), dtype=np.float64)
-    return SimulationResult(
+    return RawSimulationResult(
         ran_at=datetime(2026, 1, 1),
         horizon_months=months,
         num_runs=num_runs,

--- a/packages/simulation/tests/test_run_simulation.py
+++ b/packages/simulation/tests/test_run_simulation.py
@@ -1,22 +1,72 @@
 from datetime import date, datetime
 
 from core.defaults import default_plan
+from core.models import DEFAULT_PERCENTILES, AdvancedConfig
+from core.timeline import Timeline
 from simulation.result import ENGINE_VERSION
 
 from simulation import run_simulation
 
 
-def test_run_simulation_returns_per_run_arrays():
+def test_run_simulation_returns_percentile_major_series():
     plan = default_plan()
+    percentiles = [10, 50, 90]
 
     result = run_simulation(
         plan,
-        percentiles=[10, 50, 90],
+        percentiles=percentiles,
         today=date(2026, 1, 1),
         ran_at=datetime(2026, 1, 1),
     )
 
     assert result.engine_version == ENGINE_VERSION
+    assert result.percentiles == percentiles
     assert result.num_runs == plan.sampling.num_runs
-    assert result.balance_start.shape == (plan.sampling.num_runs, result.horizon_months)
+    assert result.balance_start.shape == (len(percentiles), result.horizon_months)
     assert result.withdrawals_total.shape == result.balance_start.shape
+    assert result.wealth_job.shape == (result.horizon_months,)
+
+
+def test_run_simulation_uses_plan_advanced_percentiles_when_kwarg_omitted():
+    plan_percentiles = [5, 25, 75, 95]
+    plan = default_plan().model_copy(
+        update={"advanced": AdvancedConfig(percentiles=plan_percentiles)}
+    )
+
+    result = run_simulation(
+        plan,
+        today=date(2026, 1, 1),
+        ran_at=datetime(2026, 1, 1),
+    )
+
+    assert result.percentiles == plan_percentiles
+
+
+def test_run_simulation_kwarg_overrides_plan_percentiles():
+    plan = default_plan()  # defaults to DEFAULT_PERCENTILES
+    override = [1, 99]
+    assert plan.advanced.percentiles == DEFAULT_PERCENTILES
+
+    result = run_simulation(
+        plan,
+        percentiles=override,
+        today=date(2026, 1, 1),
+        ran_at=datetime(2026, 1, 1),
+    )
+
+    assert result.percentiles == sorted(override)
+
+
+def test_run_simulation_start_month_and_horizon_match_timeline():
+    today = date(2026, 6, 15)
+    plan = default_plan()
+    timeline = Timeline(plan, today=today)
+
+    result = run_simulation(
+        plan,
+        today=today,
+        ran_at=datetime(2026, 6, 15),
+    )
+
+    assert result.start_month == (today.year, today.month)
+    assert result.horizon_months == timeline.horizon_months

--- a/packages/simulation/tests/test_run_simulation.py
+++ b/packages/simulation/tests/test_run_simulation.py
@@ -70,3 +70,4 @@ def test_run_simulation_start_month_and_horizon_match_timeline():
 
     assert result.start_month == (today.year, today.month)
     assert result.horizon_months == timeline.horizon_months
+    assert result.percentiles == DEFAULT_PERCENTILES


### PR DESCRIPTION
## Summary

- Add `plan.advanced.percentiles` (default `[5, 50, 95]`) with shared `normalize_percentiles` validation.
- Split engine output into private `RawSimulationResult` and public percentile-major `SimulationResult` via `numpy.percentile`.
- Add tax-prorated wealth composition bands (`wealth_job`, `wealth_social_security`, `wealth_pension`, `wealth_manual`) for stacked total-portfolio charts in Phase 4.
- Wire `run_simulation` to return the public chart-ready contract with `start_month` and resolved percentiles.

## Test plan

- [x] `make` passes locally (298 tests, ruff, pyright)
- [x] New tests: `test_advanced_config`, `test_backward_npv`, `test_composition`, `test_aggregate`, updated `test_run_simulation`
- [x] Web smoke: `results_stub.html` still reads `balance_start[0][0]`
- [x] CI green


Made with [Cursor](https://cursor.com)